### PR TITLE
Fix multilingual post titles from qTranslate

### DIFF
--- a/include/CatListDisplayer.php
+++ b/include/CatListDisplayer.php
@@ -177,9 +177,10 @@ class CatListDisplayer {
 		}
 
 		private function get_post_title($single, $tag = null, $css_class = null){
+				$title = apply_filters('the_title',$single->post_title);
 				$info = '<a href="' . get_permalink($single->ID) .
-					'" title="'. $single->post_title . '">' .
-					$single->post_title . '</a>';
+					'" title="'. $title . '">' .
+					$title . '</a>';
 				return $this->assign_style($info, $tag, $css_class);
 		}
 


### PR DESCRIPTION
Hi Fernando,

I discovered that List Category Posts was not putting post titles through the WordPress
apply_filters() function before display.  Because of this post titles
were displayed incorrectly when used with the popular qTranslate
multilingual plugin.  I found the fix mentioned in this article:
http://wordpress.stackexchange.com/questions/48322/titles-in-recent-posts-appear-together-in-all-languages-with-qtranslate

Seems to be working great on our site.  Hope this helps!
Jade
