### PR TITLE
Update CatList.php

### DIFF
--- a/include/CatList.php
+++ b/include/CatList.php
@@ -394,7 +394,7 @@ class CatList{
   }
 
   public function get_number_posts(){
-    return $this->params['numberposts'];
+    return ($this->params['numberposts']) ? $this->params['numberposts'] : 1; // Don't cause exception
   }
 
   public function get_instance(){


### PR DESCRIPTION
function get_number_posts was throwing an exception if there are no posts in the database. I changed the line to: return ($this->params['numberposts']) ? $this->params['numberposts'] : 1;
