### PR TITLE
New Attribute 'no_post_titles' for Shortocode 'catlist'

### DIFF
--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -225,8 +225,12 @@ class CatListDisplayer {
 
     $lcp_display_output = '<'. $tag . $class . '>';
 
-    $lcp_display_output .= $this->get_post_title($single);
 
+    if($this->params['no_post_titles'] == 'yes'):
+    else:
+      $lcp_display_output .= $this->get_post_title($single);
+    endif;
+    
     // Comments count
     if (!empty($this->params['comments_tag'])):
       if (!empty($this->params['comments_class'])):

--- a/list_cat_posts.php
+++ b/list_cat_posts.php
@@ -118,7 +118,8 @@ class ListCategoryPosts{
                              'pagination_next' => '>>',
                              'pagination_prev' => '<<',
                              'no_posts_text' => "",
-                             'instance' => '0'
+                             'instance' => '0',
+                             'no_post_titles' => 'no'
                            ), $atts);
     if( $atts['numberposts'] == ''){
       $atts['numberposts'] = get_option('numberposts');

--- a/readme.txt
+++ b/readme.txt
@@ -328,6 +328,8 @@ Will print the value of the Custom Field "Mood" but not the text
 
 * **link_target** - Select the `target` attribute for links to posts (target=_blank, _self, _parent, _top, *framename*). Example: `[catlink id=3 link_target=_blank]` will create: `<a href="http://localhost/wordpress/?p=45" title="Test post" target="_blank">Test post</a>`
 
+* **no_post_titles** - If set to `yes`, no post titles will be shown. This may make sense together with `content=yes`.
+
 == Widget ==
 
 The widget is quite simple, and it doesn't implement all of the plugin's functionality. To use a shortcode in a widget add this code to your theme's functions.php file:


### PR DESCRIPTION
The new attribute 'no_post_titles' is added to shortcode 'catlist',
which can have two values: 'yes' or 'no'. 'no' is the default value,
which will lead to the normal shortcode behavior as in the original
version of the plugin. 'yes' will omit the titles of the posts in
the post list.

This new option is intended for use with 'content=yes', in which
case it will basically include the post text directly without having
a separate title per entry. This allows for building bibliographies
with one literature entry per post and displaying them as lists, as
done for example on the test page
  http://thomasweise.apps-1and1.net/publications/all
(which will eventually be moved elsewhere).

The modification of the plugin is really minimal. Besides adding
the new attribute with default value 'no' in file list_cat_posts.php,
there is only one if-then-else in lcp-catlistdisplayer.php.

The documentation file readme.txt has been extended with a sentence
describing this attribute.