### PR TITLE
add custom image sizes to the list of selectable image sizes

### DIFF
--- a/include/lcp-widget-form.php
+++ b/include/lcp-widget-form.php
@@ -172,7 +172,7 @@
     <select id="<?php echo $this->get_field_id('thumbnail_size'); ?>"
       name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text">
       <?php foreach($image_sizes as $image_size) { ?>
-      <option value='<?php echo $image_size ?>'<?php
+      <option value='<?php echo $image_size ?>' <?php
         if($thumbnail_size == $image_size) echo 'selected';
       ?>><?php echo $image_size ?></option>
       <?php } ?>

--- a/include/lcp-widget-form.php
+++ b/include/lcp-widget-form.php
@@ -165,15 +165,17 @@
 </p>
 
 <p>
+  <?php $image_sizes = get_intermediate_image_sizes() ?>
   <label><?php _e("Show", 'list-category-posts')?>: </label><br/>
   <input type="checkbox" <?php checked( (bool) $instance['thumbnail'], true ); ?>
     name="<?php echo $this->get_field_name( 'thumbnail'); ?>" /> <?php _e("Thumbnail - size", 'list-category-posts')?>
     <select id="<?php echo $this->get_field_id('thumbnail_size'); ?>"
       name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text">
-      <option value='thumbnail'>thumbnail</option>
-      <option value='medium'>medium</option>
-      <option value='large'>large</option>
-      <option value='full'>full</option>
+      <?php foreach($image_sizes as $image_size) { ?>
+      <option value='<?php echo $image_size ?>'<?php
+        if($thumbnail_size == $image_size) echo 'selected';
+      ?>><?php echo $image_size ?></option>
+      <?php } ?>
     </select>
 </p>
 

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -13,13 +13,18 @@ class ListCategoryPostsWidget extends WP_Widget{
   }
 
   function widget($args, $instance) {
+    global $post;
     extract( $args );
+
     $title = empty($instance['title']) ? ' ' : apply_filters('widget_title', $instance['title']);
     $limit = (is_numeric($instance['limit'])) ? $instance['limit'] : 5;
     $orderby = ($instance['orderby']) ? $instance['orderby'] : 'date';
     $order = ($instance['order']) ? $instance['order'] : 'desc';
     $exclude = ($instance['exclude'] != '') ? $instance['exclude'] : 0;
-    $excludeposts = ($instance['excludeposts'] != '') ? $instance['excludeposts'] : 0;
+    if($instance['excludeposts'] == 'current')
+      $excludeposts = $post->ID;
+    if(!isset($excludeposts))
+      $excludeposts = ($instance['excludeposts'] != '') ? $instance['excludeposts'] : 0;
     $offset = (is_numeric($instance['offset'])) ? $instance['offset'] : 0;
     $category_id = $instance['categoryid'];
     $dateformat = ($instance['dateformat']) ? $instance['dateformat'] : get_option('date_format');
@@ -65,7 +70,6 @@ class ListCategoryPostsWidget extends WP_Widget{
       $title = '<a href="' . get_category_link($lcp_category->cat_ID) . '">' .
         $lcp_category->name . '</a>';
     } elseif ($title == 'catname') {
-      global $post;
       // If the user has setup 'catname' as the title, replace it with
       // the category link:
       $lcp_category = get_the_category($post->ID);


### PR DESCRIPTION
With this update user-defined image-sizes (i.e. custom sizes, defined in
functions.php of your theme) are considered within the selection of
thumbnail-sizes within the widget's settings.
Also, it sets the name of the selected thumbnail-size correctly after
settings have been saved and the page is reloaded.

Signed-off-by: Stefan Nussbaumer <st9fan@gmail.com>