### PR TITLE
Workaround to prevent '?&' to appear in URLs

### DIFF
--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -206,6 +206,8 @@ class CatListDisplayer {
 
       $link .= "</a></li>";
     }
+    // WA: Replace '?&' by '?' to avoid potential redirection problems later on
+    $link = str_replace('?&', '?', $link );
     return $link;
   }
 


### PR DESCRIPTION
When using one of the pagination buttons for the second time, the plugin
will generate URLs containing the substring '?&' which in turn
potentially confuses later rewrite rules. The applies WA will check the
generated URLs in the pagination and replace '?&' by a simple '?'.