### PR TITLE
Allow to order by the modified date in the widget

### DIFF
--- a/include/lcp-widget-form.php
+++ b/include/lcp-widget-form.php
@@ -111,6 +111,7 @@
     <select  id="<?php echo $this->get_field_id('orderby'); ?>"
       name="<?php echo $this->get_field_name('orderby'); ?>" type="text" >
       <?php $lcp_orders = array("date" => __("Date", "list-category-posts"),
+                                "modified" => __("Modified Date", "list-category-posts"),
                                 "title" => __("Post title", "list-category-posts"),
                                 "author" => __("Author", "list-category-posts"),
                                 "rand" => __("Random", "list-category-posts"));


### PR DESCRIPTION
The displayed string has the same case that can be found later in the file ('Modified Date' with an upper 'd' and not 'Modified date').
As this string was used before, its translation already exists.