### PR TITLE
Expanded support for Thumbnail in ListCat

### DIFF
--- a/include/lcp-thumbnail.php
+++ b/include/lcp-thumbnail.php
@@ -49,6 +49,11 @@ class LcpThumbnail{
         );
         $lcp_thumbnail .= '</a>';
       }
+      else { // if thumbnail is requested but not found as featured image, grab first image in the content of the post
+          if (preg_match('~<img[^>]*src\s?=\s?[\'"]([^\'"]*)~i',get_the_content(), $matches)) {
+              $lcp_thumbnail = '<a href="' . esc_url($matches[0]) . '" title="' . esc_attr() . '">';
+          }
+      }
     } else {
       # Check for a YouTube video thumbnail
       $lcp_thumbnail = $this->check_youtube_thumbnail($single->content);


### PR DESCRIPTION
I've added code so that if thumbnail is requested but there isn't a featued image, it will grab the first image in the post.

This is extremely helpful to ensure a consistent look and feel in the category post listing, especially in cases where there is a mix of posts with featured images vs posts that link out to other sites for an image in the post.