### PR TITLE
Expanded support for Thumbnail in ListCat

### DIFF
--- a/include/lcp-thumbnail.php
+++ b/include/lcp-thumbnail.php
@@ -49,9 +49,19 @@ class LcpThumbnail{
         );
         $lcp_thumbnail .= '</a>';
       }
-      else { // if thumbnail is requested but not found as featured image, grab first image in the content of the post
-          if (preg_match('~<img[^>]*src\s?=\s?[\'"]([^\'"]*)~i',get_the_content(), $matches)) {
-              $lcp_thumbnail = '<a href="' . esc_url($matches[0]) . '" title="' . esc_attr() . '">';
+      else {  // if thumbnail is requested but not found as featured image, grab first image in the content of the 
+          if (preg_match('~<img[^>]*src\s?=\s?[\'"]([^\'"]*)~i',get_the_content(), $imgMatches)) {
+              $lcp_thumbnail = '<a href="' . esc_url(get_permalink($single->ID)) .
+                '" title="' . esc_attr($single->post_title) . '">';
+
+              $lcp_thumbnail .= '<img src="' . esc_url($imgMatches[1]) . '" ';
+              if ( $lcp_thumb_class != null ) {  // thumbnail class passed as parameter to shortcode
+                  $lcp_thumbnail .= 'class="' . $lcp_thumb_class . '" ';
+              }
+              else { // Otherwise, use this class name
+                  $lcp_thumbnail .= 'class="lcp_thumbnail" ';
+              }
+              $lcp_thumbnail .= ' /></a>';
           }
       }
     } else {

--- a/include/lcp-thumbnail.php
+++ b/include/lcp-thumbnail.php
@@ -49,6 +49,11 @@ class LcpThumbnail{
         );
         $lcp_thumbnail .= '</a>';
       }
+      else { // if thumbnail is requested but not found as featured image, grab first image in the content of the post
+          if (preg_match('~<img[^>]*src\s?=\s?[\'"]([^\'"]*)~i',get_the_content(), $matches)) {
+              $lcp_thumbnail = '<a href="' . esc_url($matches[0]) . '" title="' . esc_attr() . '">';
+          }
+      }
     } else {
       # Check for a YouTube video thumbnail
       $lcp_thumbnail = $this->check_youtube_thumbnail($single->content);


### PR DESCRIPTION
After a lot more testing, I think this is ready to go... Live examples at www.cbtownandcountry.com/redlands-office.

I've added code so that if thumbnail is requested but there isn't a featured image, it will grab the first image in the post.
This is extremely helpful to ensure a consistent look and feel in the category post listing, especially in cases where there is a mix of posts with featured images vs posts that link out to other sites for an image in the post.

This now respects the thumbnail_class parameter if one is passed otherwise the class of lcp_thumbnail is applied to the img tag.