### PR TITLE
Handle child_categories flag correctly

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -118,7 +118,7 @@ class CatList{
       return array('category__and' => $this->lcp_category_id);
     } else {
       if($this->utils->lcp_not_empty('child_categories') && 
-         (($this->params['child_categories'] === 'no' )
+         (($this->params['child_categories'] === 'no' ) ||
           ($this->params['child_categories'] === 'false') )){
         return array('category__in'=> $this->lcp_category_id);
       }

--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -117,7 +117,9 @@ class CatList{
     if ( is_array($this->lcp_category_id) ){
       return array('category__and' => $this->lcp_category_id);
     } else {
-      if($this->utils->lcp_not_empty('child_categories') && ($this->params['child_categories'] === ('no' || 'false') )){
+      if($this->utils->lcp_not_empty('child_categories') && 
+         (($this->params['child_categories'] === 'no' )
+          ($this->params['child_categories'] === 'false') )){
         return array('category__in'=> $this->lcp_category_id);
       }
       return array('cat'=> $this->lcp_category_id);


### PR DESCRIPTION
This commit fixes how the child_category parameter is processed.
I found that the current implementation did not work correctly for me. It seemed that the branch checking for whether child_categories is set to no or false never was taken even though the parameter was set so. With these changes the if-branch is taken correctly.

Please note: There seems to be some issue with the category__in argument used, which (on my site) causes no entries to be shown at all. :(