### PR TITLE
Added Alt Tag to thumbnail

### DIFF
--- a/include/lcp-thumbnail.php
+++ b/include/lcp-thumbnail.php
@@ -61,7 +61,7 @@ class LcpThumbnail{
               else { // Otherwise, use this class name
                   $lcp_thumbnail .= 'class="lcp_thumbnail" ';
               }
-              $lcp_thumbnail .= ' /></a>';
+              $lcp_thumbnail .= ' alt="' . esc_attr($single->post_title) . '" /></a>';
           }
       }
     } else {


### PR DESCRIPTION
Seems if we are are going through the trouble of adding the thumbnail, we should probably be thorough and add an Alt tag to the image. Using the title of the article that is being linked to is probably the best course of action. Yes, we have it in the title for the link around the image but the SEO value is probably just as strong in the Alt Tag (to be picked up by Google Images, etc).

No?