### PR TITLE
Update lcp-widget.php for PHP 7 compatibility

### DIFF
--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -7,7 +7,7 @@ require_once 'lcp-catlistdisplayer.php';
 
 class ListCategoryPostsWidget extends WP_Widget{
 
-  function ListCategoryPostsWidget() {
+  function __construct() {
     $opts = array('description' => __('List posts from a specified category','list-category-posts') );
     parent::__construct(false, $name = __('List Category Posts','list-category-posts'), $opts);
   }


### PR DESCRIPTION
This fixes the error on WordPress 4.5.2 / PHP 7 (or below, needs testing) that says: "PHP Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP"

**Note:** Disregard line 118 change, as it was added by GitHub.