### PR TITLE
Iss227

### DIFF
--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -240,7 +240,7 @@ class CatListDisplayer {
       $class = 'current';
     }
 
-    if ( $this->params['tags_as_class'] == 'yes' ) {
+    if ( array_key_exists('tags_as_class', $this->params) && $this->params['tags_as_class'] == 'yes' ) {
       $post_tags = wp_get_post_Tags($single->ID);
       if ( !empty($post_tags) ){
         foreach ($post_tags as $post_tag) {

--- a/include/lcp-widget-form.php
+++ b/include/lcp-widget-form.php
@@ -21,7 +21,8 @@
                     'offset'=>'',
                     'show_catlink'=>'',
                     'morelink' =>'',
-                    'template' => ''
+                    'tags_as_class' => '',
+                    'template' => '',
                     );
   $instance = wp_parse_args( (array) $instance, $default);
 
@@ -42,6 +43,7 @@
   $thumbnail = strip_tags($instance['thumbnail']);
   $thumbnail_size = strip_tags($instance['thumbnail_size']);
   $morelink = strip_tags($instance['morelink']);
+  $tags_as_class = strip_tags($instance['tags_as_class']);
   $template = strip_tags($instance['template']);
 
 ?>
@@ -227,6 +229,20 @@
   <input class="widefat" id="<?php echo $this->get_field_id('morelink'); ?>"
     name="<?php echo $this->get_field_name('morelink'); ?>" type="text"
     value="<?php echo esc_attr($morelink); ?>" />
+</p>
+<p>
+  <label for="<?php echo $this->get_field_id('tags_as_class'); ?>">
+    <?php _e("Tags as class", 'list-category-posts'); ?>:
+  </label>
+  <br/>
+  <select id="<?php echo $this->get_field_id('tags_as_class'); ?>" name="<?php echo $this->get_field_name('tags_as_class'); ?>" type="text">
+    <option value='no' <?php if($tags_as_class == 'no'): echo "selected: selected"; endif;?>>
+      <?php _e("No", 'list-category-posts')?>
+    </option>
+    <option value='yes' <?php if($tags_as_class == 'yes'): echo "selected: selected"; endif;?>>
+      <?php _e("Yes", 'list-category-posts')?>
+    </option>
+  </select>
 </p>
 
 <p>

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -37,6 +37,7 @@ class ListCategoryPostsWidget extends WP_Widget{
     $thumbnail = ($instance['thumbnail'] == 'on') ? 'yes' : 'no';
     $thumbnail_size = ($instance['thumbnail_size']) ? $instance['thumbnail_size'] : 'thumbnail';
     $morelink = empty($instance['morelink']) ? ' ' : $instance['morelink'];
+    $tags_as_class = ($instance['tags_as_class'] == 'yes') ? 'yes' : 'no';
     $template = empty($instance['template']) ? 'default' : $instance['template'];
 
     $atts = array(
@@ -58,7 +59,8 @@ class ListCategoryPostsWidget extends WP_Widget{
       'thumbnail' => $thumbnail,
       'thumbnail_size' => $thumbnail_size,
       'morelink' => $morelink,
-      'template' => $template
+      'tags_as_class' => $tags_as_class,
+      'template' => $template,
     );
 
     echo $before_widget;
@@ -104,6 +106,7 @@ class ListCategoryPostsWidget extends WP_Widget{
     $instance['thumbnail'] = strip_tags($new_instance['thumbnail']);
     $instance['thumbnail_size'] = strip_tags($new_instance['thumbnail_size']);
     $instance['morelink'] = strip_tags($new_instance['morelink']);
+    $instance['tags_as_class'] = strip_tags($new_instance['tags_as_class']);
     $instance['template'] = strip_tags($new_instance['template']);
 
     return $instance;


### PR DESCRIPTION
Fixes https://github.com/picandocodigo/List-Category-Posts/issues/227 .

* Updated widget to support `tags_as_class` option.
* Update lcp-catlistdisplayer.php to make sure `tags_as_class` key exists in the `params` array.