### PR TITLE
Use templates by default, deprecate main `build_output`usage

### DIFF
--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -34,19 +34,12 @@ class CatListDisplayer {
   }
 
   private function select_template(){
-    // Check if we got a template param:
-    if (isset($this->params['template']) &&
-      !empty($this->params['template'])){
-      // The default values for ul, ol and div:
-      if (preg_match('/^ul$|^div$|^ol$/i', $this->params['template'], $matches)){
-        $this->build_output($matches[0]);
-      } else {
-        // Else try an actual template from the params
-        $this->template();
-      }
+    // The default values for ul, ol and div:
+    if (preg_match('/^ul$|^div$|^ol$/i', $this->params['template'], $matches)){
+      $this->build_output($matches[0]);
     } else {
-      // Default:
-      $this->build_output('ul');
+      // Else try an actual template from the params
+      $this->template();
     }
   }
 

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -57,7 +57,7 @@ class ListCategoryPosts{
                              'author_tag' =>'',
                              'author_class' => '',
                              'author_posts' => '',
-                             'template' => '',
+                             'template' => 'default',
                              'excerpt' => 'no',
                              'excerpt_size' => '55',
                              'excerpt_strip' => 'yes',


### PR DESCRIPTION
I really like the idea of using templates and being able to set them on a per-shortcode basis. However, I really don't like the idea of having to go back through all my shortcodes and update them with a default template. (I updated from an old version so the `build_output` function produces fairly different output)

I think this is the beginning of the next logical step to deprecate the `build_output` function and instead use a `default` template.

For actual inclusion, I think we need to make sure `build_output` and the `default` template have output parity. As an enhancement, I think we could also simplify down some of the template discovery and selection.