### PR TITLE
Make sure the tags_as_class instance variable is defined

### DIFF
--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -37,6 +37,9 @@ class ListCategoryPostsWidget extends WP_Widget{
     $thumbnail = ($instance['thumbnail'] == 'on') ? 'yes' : 'no';
     $thumbnail_size = ($instance['thumbnail_size']) ? $instance['thumbnail_size'] : 'thumbnail';
     $morelink = empty($instance['morelink']) ? ' ' : $instance['morelink'];
+	if ( empty( $instance['tags_as_class'] ) ) {
+		$instance['tags_as_class'] = 'no';
+	}
     $tags_as_class = ($instance['tags_as_class'] == 'yes') ? 'yes' : 'no';
     $template = empty($instance['template']) ? 'default' : $instance['template'];
 


### PR DESCRIPTION
This squelches an 'undefined index' PHP Notice that appears for
widgets that were last saved before upgrading to 0.71.1.

Fixes #231.