### PR TITLE
Custom taxonomy terms with "and" relationship

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -152,10 +152,19 @@ class LcpParameters{
     // Custom taxonomy support
     // Why didn't I document this?!?
     if ( $this->utils->lcp_not_empty('taxonomy') && $this->utils->lcp_not_empty('terms') ){
+      if ( strpos($params['terms'],'+') !== false ) {
+        $terms = explode("+",$params['terms']);
+        $operator = 'AND';
+      } else {
+        $terms = explode(",",$params['terms']);
+        $operator = 'IN';
+      }
+
       $args['tax_query'] = array(array(
         'taxonomy' => $params['taxonomy'],
         'field' => 'slug',
-        'terms' => explode(",",$params['terms'])
+        'terms' => $terms,
+        'operator' => $operator
       ));
     }
 


### PR DESCRIPTION
The current custom taxonomy implementation only supports the "or" relationship when using multiple terms. This change adds support for the "and" relationship by using the plus sign instead of the comma. Example usage: [catlist taxonomy='topic' terms='topic1+topic2']