### PR TITLE
Refactor custom fields

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -19,6 +19,7 @@ class LcpParameters{
 
   public function get_query_params($params){
     $this->params = $params;
+    $meta_query = array();
     # Essential parameters:
     $args = array(
       'numberposts' => $params['numberposts'],
@@ -124,8 +125,10 @@ class LcpParameters{
      * should both be defined
      */
     if( $this->utils->lcp_not_empty('customfield_name') ){
-      $args['meta_key'] = $params['customfield_name'];
-      $args['meta_value'] = $params['customfield_value'];
+      $meta_query['select_clause'] = array(
+        'key' => $params['customfield_name'],
+        'value' => $params['customfield_value']
+      );
     }
 
     //Get private posts
@@ -204,8 +207,17 @@ class LcpParameters{
     }
 
     if ( $this->utils->lcp_not_empty('customfield_orderby') ){
-      $args['orderby'] = 'meta_value';
-      $args['meta_key'] = $params['customfield_orderby'];
+      $meta_query['orderby_clause'] = array(
+        'key' => $params['customfield_orderby'],
+        'compare' => 'EXISTS',
+      );
+      $args['orderby'] = 'orderby_clause';
+    }
+    
+    // If either select_clause or orderby_clause were added to $meta_query,
+    // it needs to be added to args.
+    if ( !empty($meta_query) ) {
+      $args['meta_query'] = $meta_query;
     }
 
     // Posts that start with a given letter:

--- a/readme.txt
+++ b/readme.txt
@@ -151,7 +151,7 @@ When using List Category Posts whithout a category id, name or slug, it will pos
 * **post_parent** - Show only the children of the post with this ID.
     Default: None.
 
-* **custom fields** - To use custom fields, you must specify two values: customfield_name and customfield_value. `customfield_name` defines the name of the field, and you should choose the values for which you want posts to display. Using this only show posts that contain a custom field with this name and value. Both parameters must be defined, or neither will work. Eg: `[catlist customfield_name="color" customfield_value="green"]` will display posts with the value `green` set on the custom field `color`.
+* **custom fields** - To use custom fields, you must specify two values: customfield_name and customfield_value. `customfield_name` defines the name of the field, and you should choose the values for which you want posts to display. Using this only show posts that contain a custom field with this name and value. Both parameters must be defined, or neither will work. Eg: `[catlist customfield_name="color" customfield_value="green"]` will display posts with the value `green` set on the custom field `color`. This parameter can be used together with `customfield_orderby`, see further below for more information.
 
 ==PAGINATION
 
@@ -187,7 +187,7 @@ https://github.com/picandocodigo/List-Category-Posts/wiki/Pagination
   * **title** - Sort by title.
   * **type** - Sort by type. Ex: `[catlist name=mycategory orderby=date]`
 
-* **customfield_orderby** - You can order the posts by a custom field. For example: `[catlist numberposts=-1 customfield_orderby=Mood order=desc]` will list all the posts with a "Mood" custom field. Remember the default order is descending, more on order:
+* **customfield_orderby** - You can order the posts by a custom field. For example: `[catlist numberposts=-1 customfield_orderby=Mood order=desc]` will list all the posts with a "Mood" custom field. This parameter can be used toghether with `customfield_name` and `customfield_value`, you can use those parameters to select posts and then `customfield_orderby` to sort by this or another custom field.  Remember the default order is descending, more on order:
 
 * **order** - How to sort **orderby**. Valid values are:
   * **ASC** - Ascending (lowest to highest).


### PR DESCRIPTION
#261 was closed but the issue is unresolved so I devised this quick fix. Since it was discussed in that thread I will skip the description here.

Instead of using simple parameters like `meta_key` I'm passing `meta_query`, an array of arrays. This allows for all sorts of magic that WP_Meta_Query has. 