### PR TITLE
Fix pagination parameter/option

### DIFF
--- a/include/lcp-paginator.php
+++ b/include/lcp-paginator.php
@@ -24,10 +24,14 @@ class LcpPaginator {
   # override general options).
   # Receives params['pagination'] from CatList
   private function show_pagination($pagination){
-    return !empty($pagination) &&
-           $pagination == 'yes' ||
+    return (!empty($pagination) && (
+            $pagination == 'yes' ||
+            $pagination == 'true')
+           )
+           ||
            (get_option('lcp_pagination') === 'true' &&
-            ($pagination !== 'false')
+            ($pagination !== 'false') &&
+            ($pagination !== 'no')
            );
   }
 

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -73,6 +73,8 @@ class ListCategoryPostsWidget extends WP_Widget{
 
     echo $before_widget;
 
+    if ($pagination === 'yes') lcp_pagination_css();
+
     if ($title == 'catlink') {
       // If the user has setup 'catlink' as the title, replace it with
       // the category link:

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -126,7 +126,7 @@ class ListCategoryPosts{
                              'monthnum' => '',
                              'search' => '',
                              'link_target' => '',
-                             'pagination' => 'no',
+                             'pagination' => '',
                              'pagination_next' => '>>',
                              'pagination_prev' => '<<',
                              'no_posts_text' => "",


### PR DESCRIPTION
Two fixes in this PR:
* c5a0b27 didn't fully work, if there is no `pagination=yes` but backend option is set to `true`, no pagination will be displayed right now. I fixed the logic in `lcp-paginator.php`
* The wiki says `pagination` can be set to `yes` or `no`, but the code looks for `yes` or `false`. I fixed this for consistency