### PR TITLE
Add tests for LcpPaginator

### DIFF
--- a/tests/lcppaginator/test-getInstance.php
+++ b/tests/lcppaginator/test-getInstance.php
@@ -1,0 +1,16 @@
+<?php
+
+class Tests_LcpPaginator_GetInstance extends WP_UnitTestCase {
+
+    public function test_if_returns_instance() {
+        $paginator = LcpPaginator::get_instance();
+        $this->assertSame(true, $paginator instanceof LcpPaginator);
+    }
+
+    public function test_singleton_instantiation() {
+        $paginator1 = LcpPaginator::get_instance();
+        $paginator2 = LcpPaginator::get_instance();
+
+        $this->assertSame($paginator1, $paginator2);
+    }
+}

--- a/tests/lcppaginator/test-getPagination.php
+++ b/tests/lcppaginator/test-getPagination.php
@@ -1,0 +1,139 @@
+<?php
+
+class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
+   
+    // Spoof params lcp_page_link requires to work
+    protected $test_params = array(
+        'posts_count' => '6',
+        'numberposts' => '2',
+        'page' => 1,
+        'instance' => '0',
+        'next' => '>>',
+        'previous' => '<<'
+    );
+
+    public static function wpSetUpBeforeClass($factory) {
+        // Insert 6 random posts into the test db
+        $factory->post->create_many(6);
+            
+        // Spoof QUERY_STRING becuase URL rewriting is off
+        // and lcp_page_link directly accesses it (avoid 'undefined index')
+        $_SERVER['QUERY_STRING'] = '';
+    }
+
+    public function test_should_display_pagination() {
+        $paginator = LcpPaginator::get_instance();
+
+        // Spoof params lcp_page_link requires to work
+        $test_params = array(
+            'posts_count' => '6',
+            'numberposts' => '2',
+            'page' => '1',
+            'instance' => '0',
+            'next' => '>>'
+        );
+
+        // Empty shortcode parameter, 'false' in backend
+        update_option('lcp_pagination', 'false');
+        $params = array('pagination' => '');
+        $this->assertSame(null, $paginator->get_pagination($params));
+
+        // Random string as parameter, 'false' in backend
+        $params = array('pagination' => 'this is a random string');
+        $this->assertSame(null, $paginator->get_pagination($params));
+
+        // 'yes' as parameter, 'false' in backend
+        $params = array_merge(array('pagination' => 'yes'),
+                              $this->test_params);
+        $this->assertTrue(is_string($paginator->get_pagination($params)));
+
+        // 'true' as parameter, 'false' in backend
+        $params = array_merge(array('pagination' => 'true'),
+                              $this->test_params);
+        $this->assertTrue(is_string($paginator->get_pagination($params)));
+
+        // 'false' as parameter, 'false' in backend
+        $params = array('pagination' => 'false');
+        $this->assertSame(null, $paginator->get_pagination($params));
+
+        // 'no' as parameter, 'false' in backend
+        $params = array('pagination' => 'no');
+        $this->assertSame(null, $paginator->get_pagination($params));
+
+        update_option('lcp_pagination', 'true');
+
+        // Empty shortcode parameter, 'true' in backend
+        $params = array_merge(array('pagination' => 'this is a random string'),
+                              $this->test_params);
+        $this->assertTrue(is_string($paginator->get_pagination($params)));
+
+        // Random string as parameter, 'true' in backend
+        $params = array_merge(array('pagination' => 'this is a random string'),
+                              $this->test_params);
+        $this->assertTrue(is_string($paginator->get_pagination($params)));
+
+        // 'yes' as parameter, 'true' in backend
+        $params = array_merge(array('pagination' => 'yes'),
+                              $this->test_params);
+        $this->assertTrue(is_string($paginator->get_pagination($params)));
+
+        // 'true' as parameter, 'true' in backend
+        $params = array_merge(array('pagination' => 'true'),
+                              $this->test_params);
+        $this->assertTrue(is_string($paginator->get_pagination($params)));
+
+        // 'no' as parameter, 'false' in backend
+        $params = array('pagination' => 'no');
+        $this->assertSame(null, $paginator->get_pagination($params));
+
+        // 'false' as parameter, 'true' in backend
+        $params = array('pagination' => 'false');
+        $this->assertSame(null, $paginator->get_pagination($params));
+    }
+
+    public function test_pagination_string() {
+        $paginator = LcpPaginator::get_instance();
+
+        // Check first page
+        $params = array_merge(array('pagination' => 'yes'),
+                              $this->test_params);
+        $pag_string = $paginator->get_pagination($params);
+
+        $exp_string = "<ul class='lcp_paginator'>" .
+                      "<li class='lcp_currentpage'>1</li>" .
+                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2' class='lcp_nextlink'>2</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=3#lcp_instance_0' title='3'>3</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2' class='lcp_nextlink'>>></a></li>" .
+                      "</ul>";
+        $this->assertSame($exp_string, $pag_string);
+
+        // Check second page
+        $params = array_merge($this->test_params,
+                              array('pagination' => 'yes', 'page' => 2));
+
+        $pag_string = $paginator->get_pagination($params);
+
+        $exp_string = "<ul class='lcp_paginator'>" .
+                      "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1' class='lcp_prevlink'><<</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1'>1</a></li>" .
+                      "<li class='lcp_currentpage'>2</li>" .
+                      "<li><a href='http://example.org?lcp_page0=3#lcp_instance_0' title='3'>3</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=3#lcp_instance_0' title='3' class='lcp_nextlink'>>></a></li>" .
+                      "</ul>";
+        $this->assertSame($exp_string, $pag_string);
+
+        // Check last page
+        $params = array_merge($this->test_params,
+                              array('pagination' => 'yes', 'page' => 3));
+
+        $pag_string = $paginator->get_pagination($params);
+
+        $exp_string = "<ul class='lcp_paginator'>" .
+                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2' class='lcp_prevlink'><<</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1' class='lcp_prevlink'>1</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2'>2</a></li>" .
+                      "<li class='lcp_currentpage'>3</li>" .
+                      "</ul>";
+        $this->assertSame($exp_string, $pag_string);
+    }
+}


### PR DESCRIPTION
Ok, last one I can send you this year, but it's an important one. This is quite an extensive plugin, with many moving parts, I want it to live a long and healthy life :wink: so I believe we'd all feel much more comfortable with a good test suite. I started by writing unit tests, testing public functions in isolation. Then more complex inegration tests can be written. This PR contains a comprehensive test suite for the `LcpPaginator` class.

I also want to introduce a very specific naming and directory structure convention:
* in the `tests` directory there will be a subdirectory named after every PHP class, lowercase
* in these subdirectories there will be files named after public functions they test, naming: `test-[publicFunctionName].php`, for example `test-getPagination.php`
* in each file there will be one class called `Tests_[ClassName]_[FunctionName]`, e. g. `Tests_LcpPaginator_GetPagination`.