### PR TITLE
Refactor pagination check

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -96,7 +96,7 @@ class CatList{
   /** HELPER FUNCTIONS **/
 
   private function check_pagination($args){
-    if ( $this->utils->lcp_not_empty('pagination') ){
+    if ( LcpUtils::lcp_show_pagination($this->params['pagination']) ){
       if( array_key_exists('QUERY_STRING', $_SERVER) && null !== $_SERVER['QUERY_STRING'] ){
         $query = $_SERVER['QUERY_STRING'];
         if ($query !== '' && preg_match('/lcp_page' . preg_quote($this->instance) .

--- a/include/lcp-paginator.php
+++ b/include/lcp-paginator.php
@@ -23,20 +23,9 @@ class LcpPaginator {
   # is not set to 'no' (since shortcode parameters should
   # override general options).
   # Receives params['pagination'] from CatList
-  private function show_pagination($pagination){
-    return (!empty($pagination) && (
-            $pagination == 'yes' ||
-            $pagination == 'true')
-           )
-           ||
-           (get_option('lcp_pagination') === 'true' &&
-            ($pagination !== 'false') &&
-            ($pagination !== 'no')
-           );
-  }
 
   public function get_pagination($params){
-    if ($this->show_pagination($params['pagination'])){
+    if (LcpUtils::lcp_show_pagination($params['pagination'])){
       $lcp_paginator = '';
       $pages_count = ceil (
           $params['posts_count'] /

--- a/include/lcp-utils.php
+++ b/include/lcp-utils.php
@@ -17,11 +17,23 @@ class LcpUtils{
     );
   }
 
-    public static function lcp_orders(){
-      return array("date" => __("Date", "list-category-posts"),
-                   "modified" => __("Modified Date", "list-category-posts"),
-                   "title" => __("Post title", "list-category-posts"),
-                   "author" => __("Author", "list-category-posts"),
-                   "rand" => __("Random", "list-category-posts"));
-    }
+  public static function lcp_orders(){
+    return array("date" => __("Date", "list-category-posts"),
+                 "modified" => __("Modified Date", "list-category-posts"),
+                 "title" => __("Post title", "list-category-posts"),
+                 "author" => __("Author", "list-category-posts"),
+                 "rand" => __("Random", "list-category-posts"));
+  }
+  
+  public static function lcp_show_pagination($pagination){
+    return (!empty($pagination) && (
+            $pagination == 'yes' ||
+            $pagination == 'true')
+           )
+           ||
+           (get_option('lcp_pagination') === 'true' &&
+            ($pagination !== 'false') &&
+            ($pagination !== 'no')
+           );
+  }
 }


### PR DESCRIPTION
The `check_pagination` method in `CatList` is outdated, it doesn't check if pagination is on in a proper way, it only looks if the parameter exists but doesn't care about its value, it also disregards backend options.

I noticed this while refactoring the code for less repetition. My refactoring fixes the above problem:
* I moved the `show_pagination` method of `LcpPaginator` to `LcpUtils` to make it reusable
* then I changed the `check_pagination` method to perform a proper check using `LcpUtils`
* I also fixed indentation in `LcpUtils` for consistency