### PR TITLE
Refactor CatListDisplayer, add some tests

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -218,7 +218,17 @@ class CatList{
     endif;
   }
 
-
+  public function get_posts_morelink($single, $css_class) {
+    if(!empty($this->params['posts_morelink'])){
+      $href = 'href="' . get_permalink($single->ID) . '"';
+      $class = $css_class ?: "";
+      if ( $class ):
+        $class = 'class="' . $class . '" ';
+      endif;
+      $readmore = $this->params['posts_morelink'];
+      return ' <a ' . $href . ' ' . $class . ' >' . $readmore . '</a>';
+    }
+  }
 
   public function get_category_count(){
     if($this->utils->lcp_not_empty('category_count') && $this->params['category_count'] == 'yes'):
@@ -268,6 +278,12 @@ class CatList{
           endforeach;
         endif;
       endforeach;
+
+      // Return a string instead of array if custom fields
+      // are not displayed separately.
+      if ($this->params['customfield_display_separately'] === 'no') {
+        $lcp_customs = implode($this->params['customfield_display_glue'], $lcp_customs);
+      }
 
       return $lcp_customs;
     else:
@@ -330,7 +346,7 @@ class CatList{
 
   public function get_modified_date_to_show($single){
     if ($this->params['date_modified'] == 'yes'):
-      return get_the_modified_time($this->params['dateformat'], $single);
+      return " " . get_the_modified_time($this->params['dateformat'], $single);
     else:
       return null;
     endif;

--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -332,7 +332,7 @@ class CatListDisplayer {
       if ( !empty($this->params['link_dates']) && ( 'yes' === $this->params['link_dates'] || 'true' === $this->params['link_dates'] ) ):
       $info = $this->get_post_link($post, $info);
       endif;
-      $info = ' ' . $info;
+      ($info) ? ($info = ' ' . $info) : null;
       break;
     case 'thumbnail':
       $info = $this->catlist->get_thumbnail($post, $css_class);

--- a/include/lcp-wrapper.php
+++ b/include/lcp-wrapper.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This class handles HTML customizations
+ * defined by the user, both in shortcode parameters (e.g. comments_tag)
+ * and in template method calls.
+ */
+class LcpWrapper {
+
+  // Singleton implementation
+  private static $instance = null;
+  public static function get_instance(){
+    if( !isset( self::$instance ) ){
+      self::$instance = new self;
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Several checks going on here:
+   * - Tag provided, no class - wrap content with tag
+   * - Tag and class provided - wrap content with tag and class
+   * - Class provided, no tag - wrap content with span and class
+   * @param string $info
+   * @param string $tag
+   * @param string $css_class
+   * @return string
+   */
+  private function assign_style($info, $tag = null, $css_class = null){
+    if (!empty($info)):
+      if (empty($tag) && !empty($css_class)):
+        $tag = "span";
+      elseif (empty($tag)):
+        return $info;
+      elseif (!empty($tag) && empty($css_class)) :
+        return '<' . $tag . '>' . $info . '</' . $tag . '>';
+      endif;
+      $css_class = sanitize_html_class($css_class);
+      return '<' . $tag . ' class="' . $css_class . '">' . $info . '</' . $tag . '>';
+    endif;
+  }
+
+  /**
+   * Assign style to the info delivered by CatList. Tag is an HTML tag
+   * which is passed and will sorround the info. Css_class is the css
+   * class we want to assign to this tag. If an array is passed to $info
+   * each element will be wrapped separately and added to the returned string.
+   * @param string|array $info
+   * @param string $tag
+   * @param string $css_class
+   * @return string
+   */
+  public function wrap($info, $tag=null, $css_class=null) {
+
+    $wrapped = '';
+
+    if (is_array($info)) {
+      foreach ($info as $i) {
+        $wrapped .= $this->assign_style($i, $tag, $css_class);
+      }
+    } else {
+      $wrapped = $this->assign_style($info, $tag, $css_class);
+    }
+    return $wrapped;
+  }
+}

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -83,6 +83,7 @@ class ListCategoryPosts{
         'starting_with' => '',
         'thumbnail' => 'no',
         'thumbnail_size' => 'thumbnail',
+        'thumbnail_tag' => '',
         'thumbnail_class' => '',
         'force_thumbnail' => '',
         'title_tag' => '',

--- a/tests/catlistdisplayer/test-display.php
+++ b/tests/catlistdisplayer/test-display.php
@@ -32,7 +32,7 @@ class Tests_CatListDisplayer_Display extends WP_UnitTestCase {
     $displayer = new CatListDisplayer(array_merge(ListCategoryPosts::default_params()));
 
     $this->assertSame('<ul class="lcp_catlist" id="lcp_instance_0">' .
-                      '<li class="current"><a href="http://example.org/?p=' . $test_post->ID . 
+                      '<li ><a href="http://example.org/?p=' . $test_post->ID .
                       '" title="Test post">Test post</a></li></ul>',
                       $displayer->display());
   }

--- a/tests/catlistdisplayer/test-display.php
+++ b/tests/catlistdisplayer/test-display.php
@@ -1,0 +1,39 @@
+<?php
+
+class Tests_CatListDisplayer_Display extends WP_UnitTestCase {
+
+  public function test_return_type() {
+    // Insert 3 random posts into the test db
+    self::factory()->post->create_many(3);
+    $displayer = new CatListDisplayer(ListCategoryPosts::default_params());
+    
+    $this->assertTrue(is_string($displayer->display()));
+  }
+
+  public function test_tags_and_classes_params() {
+    // Parameter evaluation works exactly the same for every type
+    // so this test case only checks 'comments' as an example.
+    
+    $test_post = self::factory()->post->create_and_get(array(
+      'post_title' => 'Test post'
+    ));
+    self::factory()->comment->create_post_comments($test_post->ID);
+    $params = array('comments' => 'yes', 'comments_tag' => 'p', 'comments_class' => 'test');
+    
+    $displayer = new CatListDisplayer(array_merge(ListCategoryPosts::default_params(), $params));
+
+    $this->assertSame('<ul class="lcp_catlist" id="lcp_instance_0">' .
+                      '<li ><a href="http://example.org/?p=' . $test_post->ID . 
+                      '" title="Test post">Test post</a>' .
+                      '<p class="test"> (1)</p></li></ul>',
+                      $displayer->display());
+
+    // Without tag or class given
+    $displayer = new CatListDisplayer(array_merge(ListCategoryPosts::default_params()));
+
+    $this->assertSame('<ul class="lcp_catlist" id="lcp_instance_0">' .
+                      '<li class="current"><a href="http://example.org/?p=' . $test_post->ID . 
+                      '" title="Test post">Test post</a></li></ul>',
+                      $displayer->display());
+  }
+}

--- a/tests/lcpwrapper/test-getInstance.php
+++ b/tests/lcpwrapper/test-getInstance.php
@@ -1,0 +1,16 @@
+<?php
+
+class Tests_LcpWrapper_GetInstance extends WP_UnitTestCase {
+
+    public function test_if_returns_instance() {
+        $paginator = LcpWrapper::get_instance();
+        $this->assertTrue($paginator instanceof LcpWrapper);
+    }
+
+    public function test_singleton_instantiation() {
+        $paginator1 = LcpWrapper::get_instance();
+        $paginator2 = LcpWrapper::get_instance();
+
+        $this->assertSame($paginator1, $paginator2);
+    }
+}

--- a/tests/lcpwrapper/test-wrap.php
+++ b/tests/lcpwrapper/test-wrap.php
@@ -1,0 +1,42 @@
+<?php
+
+class Tests_LcpWrapper_Wrap extends WP_UnitTestCase {
+
+  private $test_string = 'test string';
+
+  public function test_no_tag_no_class() {
+    $wrapper = LcpWrapper::get_instance();
+    $this->assertSame('test string', $wrapper->wrap($this->test_string));
+  }
+
+  public function test_tag_no_class() {
+    $wrapper = LcpWrapper::get_instance();
+    $this->assertSame('<div>test string</div>',
+                      $wrapper->wrap($this->test_string, 'div'));
+  }
+
+  public function test_no_tag_class() {
+    $wrapper = LcpWrapper::get_instance();
+    // When class provided but no tag, <span> is the default tag.
+    $this->assertSame('<span class="test">test string</span>',
+                      $wrapper->wrap($this->test_string, null, 'test'));
+  }
+
+  public function test_tag_class() {
+    $wrapper = LcpWrapper::get_instance();
+    $this->assertSame('<article class="test">test string</article>',
+                      $wrapper->wrap($this->test_string, 'article', 'test'));
+  }
+
+  public function test_array_as_info() {
+    $wrapper = LcpWrapper::get_instance();
+    $test_array = array('this', 'is', 'an', 'array');
+
+    $this->assertSame('thisisanarray', $wrapper->wrap($test_array));
+    $this->assertSame('<p>this</p><p>is</p><p>an</p><p>array</p>',
+                      $wrapper->wrap($test_array, 'p'));
+    $this->assertSame('<p class="test">this</p><p class="test">is</p>' .
+                      '<p class="test">an</p><p class="test">array</p>',
+                      $wrapper->wrap($test_array, 'p', 'test'));
+  }
+}


### PR DESCRIPTION
I only wanted to refactor `CatListDisplayer` and create `LcpWrapper` but it quickly turned out that to do it properly I have to change many other files...

Anyway, I moved wrapping with tags and classes to `LcpWrapper`. This PR alters many lines of code but in most cases for clarity and ease of use, not much changes in how the plugin works, except:

* `something_tag` and `something_class` parameters now work in all template functions, they take precedence over arguments
* some template functions now have default parameter values to match simple shortcode bahaviour, e. g. `get_category_link($tag = 'strong', $css_class = null)`
* I added `thumbnail_tag` because template function already had this feature but default build function didn't

Other thigs that don't change how things work but are important to mention:

* Added complete tests for LcpWrapper
* Added tests for `CatListDisplayer` but this is work in progress, test cases I wrote are a good start though, we need even more refactoring to write good tests for this class...

I edited the readme, but the incosistencies I mentioned in #284 are mostly in the wiki, especially the html & css section, I'll fix them once this is merged. 
  
Fixes #282 