### PR TITLE
Fixes for widget, tests for current_category

### DIFF
--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -59,7 +59,7 @@ class LcpCategory{
   }
 
   public function current_category(){
-    $category = get_category( get_query_var( 'category' ) );
+    $category = get_category( get_query_var( 'cat' ) );
     if( isset( $category->errors ) && $category->errors["invalid_term"][0] == __("Empty Term.") ){
       global $post;
       $categories = get_the_category($post->ID);

--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -7,7 +7,7 @@
 require_once 'lcp-catlist.php';
 
 class CatListDisplayer {
-  private $catlist;
+  public $catlist;
   private $params = array();
   private $lcp_output;
 

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -83,7 +83,9 @@ class ListCategoryPostsWidget extends WP_Widget{
 
     // Fetch the category id from the Catlist instance.
     $category_id = $catlist_displayer->catlist->get_category_id();
-    if ($title == 'catlink') {
+    if ($category_id === null && ($title == 'catlink' || $title == 'catname')) {
+      $title = '';
+    } elseif ($title == 'catlink') {
       // If the user has setup 'catlink' as the title, replace it with
       // the category link:
       $lcp_category = get_category($category_id);

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -75,6 +75,14 @@ class ListCategoryPostsWidget extends WP_Widget{
 
     if ($pagination === 'yes') lcp_pagination_css();
 
+    // To make the widget title replacement work with "Current category" we need to
+    // run the displayer here to determine the current cat id.
+    // Otherwise the id remains set to "-1".
+    $catlist_displayer = new CatListDisplayer($atts);
+    $lcp_display = $catlist_displayer->display();
+
+    // Fetch the category id from the Catlist instance.
+    $category_id = $catlist_displayer->catlist->get_category_id();
     if ($title == 'catlink') {
       // If the user has setup 'catlink' as the title, replace it with
       // the category link:
@@ -84,13 +92,12 @@ class ListCategoryPostsWidget extends WP_Widget{
     } elseif ($title == 'catname') {
       // If the user has setup 'catname' as the title, replace it with
       // the category link:
-      $lcp_category = get_the_category($post->ID);
-      $title = $lcp_category[0]->name;
+      $lcp_category = get_category($category_id);
+      $title = $lcp_category->name;
     }
     echo $before_title . $title . $after_title;
 
-    $catlist_displayer = new CatListDisplayer($atts);
-    echo  $catlist_displayer->display();
+    echo $lcp_display;
     echo $after_widget;
   }
 

--- a/tests/lcpcategory/test-currentCategory.php
+++ b/tests/lcpcategory/test-currentCategory.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @runTestsInSeparateProcesses
+ */
+class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
+
+  protected static $test_post;
+  protected static $test_page;
+  protected static $test_cat;
+
+  public static function wpSetUpBeforeClass($factory) {
+    // Create some random categories
+    $factory->term->create_many(5, array(
+      'taxonomy' => 'category'
+    ));
+    // Add some posts to each category
+    foreach(get_categories(array('hide_empty' => 0)) as $category) {
+      $factory->post->create_many(10, array(
+        'post_category' => array($category->cat_ID)
+      ));
+    }
+
+    // Create test category, test post and test page (no categories for page)
+    self::$test_cat = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name' => 'Lcp test cat'
+    ));
+
+    self::$test_post = $factory->post->create(array(
+      'post_title' => 'Lcp test post',
+      'post_category' => array(self::$test_cat)
+    ));
+
+    self::$test_page = $factory->post->create(array(
+      'post_title' => 'Lcp test page',
+      'post_type' => 'page'
+    ));
+  }
+
+  public function test_category_archive() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    // Check if every category is detected properly
+    $categories = get_categories();
+    foreach($categories as $category) {
+      $this->go_to('/?cat=' . $category->cat_ID);
+      $this->assertQueryTrue('is_category', 'is_archive');
+
+      $this->assertSame($category->cat_ID, $lcpcategory->current_category());
+    }
+  }
+
+  public function test_single_post_page() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to('/?p=' . self::$test_post);
+    $this->assertQueryTrue('is_singular', 'is_single');
+    $this->assertSame(self::$test_cat, $lcpcategory->current_category());
+    $this->assertSame('Lcp test cat', get_category($lcpcategory->current_category())->cat_name);
+  }
+
+  public function test_single_page_with_no_categories() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to('/?page_id=' . self::$test_page);
+    $this->assertQueryTrue('is_singular', 'is_page');
+    $this->assertSame(null, $lcpcategory->current_category());
+  }
+}
+
+// TODO: write tests for month archives and home page, but this
+// requires changing the curent_category method so that it can handle those cases.


### PR DESCRIPTION
This is the result of these two threads:
* [Thread 1](https://wordpress.org/support/topic/categorypageyes-is-not-detecting-the-correct-category-sometimes/)
* [Thread 2](https://wordpress.org/support/topic/catlink-on-title-field-of-widget-does-not-work/)

Many thanks to infinityx78 for suggestions!

Since this is all about 'current category' I'm throwing in initial tests for LcpCategory.

Fixes #155 