### PR TITLE
Use regular function instead of create_function

### DIFF
--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -138,4 +138,7 @@ class ListCategoryPostsWidget extends WP_Widget{
   }
 }
 
-add_action('widgets_init', create_function('', 'return register_widget("listCategoryPostsWidget");'));
+function lcp_register_widget() {
+  return register_widget("listCategoryPostsWidget");
+}
+add_action('widgets_init', 'lcp_register_widget');


### PR DESCRIPTION
create_function is deprecated as of PHP 7.2.0
Not using an anonymous function because as of now it breaks PHPUnit.

Fixes [this issue](https://wordpress.org/support/topic/php-deprecated-function-create_function-is-deprecated-2/)