### PR TITLE
Fix date query

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -346,9 +346,9 @@ class LcpParameters{
      *  should be created.
      */
     foreach ($params_set as $key=>$value){
-      if ( isset($this->{$key}) ){
+      if ( property_exists($this, $key) ){
         $params_set[$key] = true;
-        $trutify = substr($key, 0, strpos( $key, '_') );
+        $trutify = explode('_', $key)[0];
         ${$trutify} = true;
       }
     }


### PR DESCRIPTION
Issue reported by stefanr on WP Support Forum.
https://wordpress.org/support/topic/after-not-creating-date-query/

He was correct in that thread, `after` and `before` don't work at all. But I like my solution more than his 😛 