### PR TITLE
Restore PHP < 5.4 compatibility

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -348,7 +348,8 @@ class LcpParameters{
     foreach ($params_set as $key=>$value){
       if ( property_exists($this, $key) ){
         $params_set[$key] = true;
-        $trutify = explode('_', $key)[0];
+        $trutify = explode('_', $key);
+        $trutify = $trutify[0];
         ${$trutify} = true;
       }
     }


### PR DESCRIPTION
https://wordpress.org/support/topic/fatal-error-after-0-76-update/

So maybe better release this hotfix and add a deprecation warning in the changelog that we will be dropping support for pre 5.4 because those old versions are really dumb with arrays.