### PR TITLE
 Add instantiation tests for all classes 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 
 # Versions of PHP to test against
 php:
-  - 5.5
+  - 5.4
   - 7.0
 
 # Specify versions of WordPress to test against

--- a/tests/catlist/test-construct.php
+++ b/tests/catlist/test-construct.php
@@ -1,0 +1,10 @@
+<?php
+
+class Tests_CatList_Construct extends WP_UnitTestCase {
+
+  public function test_instantiation() {
+    $catlist = new CatList(['instance' => 1]);
+
+    $this->assertTrue($catlist instanceof CatList);
+  }
+}

--- a/tests/catlistdisplayer/test-construct.php
+++ b/tests/catlistdisplayer/test-construct.php
@@ -1,0 +1,17 @@
+<?php
+
+class Tests_CatListDisplayer_Construct extends WP_UnitTestCase {
+
+  public function test_instantiation() {
+    $displayer = new CatListDisplayer(['instance' => 1]);
+
+    $this->assertTrue($displayer instanceof CatListDisplayer);
+  }
+
+  public function test_created_properties() {
+    $displayer = new CatListDisplayer(['instance' => 1]);
+
+    $this->assertTrue($displayer->catlist instanceof CatList);
+    $this->assertTrue(property_exists($displayer, 'parent'));
+  }
+}

--- a/tests/lcpparameters/test-getInstance.php
+++ b/tests/lcpparameters/test-getInstance.php
@@ -1,0 +1,16 @@
+<?php
+
+class Tests_LcpParameters_GetInstance extends WP_UnitTestCase {
+
+  public function test_if_returns_instance() {
+    $parameters = LcpParameters::get_instance();
+    $this->assertTrue($parameters instanceof LcpParameters);
+  }
+
+  public function test_singleton_instantiation() {
+    $parameters1 = LcpParameters::get_instance();
+    $parameters2 = LcpParameters::get_instance();
+
+    $this->assertSame($parameters1, $parameters2);
+  }
+}

--- a/tests/lcpthumbnail/test-getInstance.php
+++ b/tests/lcpthumbnail/test-getInstance.php
@@ -1,0 +1,16 @@
+<?php
+
+class Tests_LcpThumbnail_GetInstance extends WP_UnitTestCase {
+
+  public function test_if_returns_instance() {
+    $thumbnail = LcpThumbnail::get_instance();
+    $this->assertTrue($thumbnail instanceof LcpThumbnail);
+  }
+
+  public function test_singleton_instantiation() {
+    $thumbnail1 = LcpThumbnail::get_instance();
+    $thumbnail2 = LcpThumbnail::get_instance();
+
+    $this->assertSame($thumbnail1, $thumbnail2);
+  }
+}

--- a/tests/lcpwidget/test-construct.php
+++ b/tests/lcpwidget/test-construct.php
@@ -1,0 +1,19 @@
+<?php
+
+class Tests_ListCategoryPostsWidget_Construct extends WP_UnitTestCase {
+
+  public function test_instantiation() {
+    $widget = new ListCategoryPostsWidget();
+
+    $this->assertTrue($widget instanceof ListCategoryPostsWidget);
+  }
+
+  public function test_created_properties() {
+    $widget = new ListCategoryPostsWidget();
+
+    $this->assertSame('listcategorypostswidget', $widget->id_base);
+    $this->assertSame(__('List Category Posts','list-category-posts'), $widget->name);
+    $this->assertSame(__('List posts from a specified category','list-category-posts'),
+                      $widget->widget_options['description']);
+  }
+}


### PR DESCRIPTION
Travis CI modified to run the lowest and highest PHP version we are supporting. I quickly threw up together instantiation tests for all classes. This forces phpunit to parse their code and catch any errors that could originate from something incompatible with 5.4