### PR TITLE
Parametrise bookmarks in pagination links

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -430,7 +430,8 @@ class CatList{
           'page'        => $this->get_page(),
           'pagination'  => $this->params['pagination'],
           'posts_count' => $this->get_posts_count(),
-          'previous'    => $this->params['pagination_prev']
+          'previous'    => $this->params['pagination_prev'],
+          'bookmarks'   => $this->params['pagination_bookmarks']
     );
     return LcpPaginator::get_instance()->get_pagination($paginator_params);
   }

--- a/include/lcp-paginator.php
+++ b/include/lcp-paginator.php
@@ -37,7 +37,8 @@ class LcpPaginator {
       $this->next_page_num = null;
       if ($pages_count > 1){
           for($i = 1; $i <= $pages_count; $i++){
-              $lcp_paginator .=  $this->lcp_page_link($i, $params['page'], $params['instance']);
+              $lcp_paginator .=  $this->lcp_page_link($i, $params['page'], $params['instance'],
+                                                      null, $params['bookmarks']);
           }
 
           $pag_output .= "<ul class='lcp_paginator'>";
@@ -45,7 +46,8 @@ class LcpPaginator {
           // Add "Previous" link
           if ($params['page'] > 1){
             $this->prev_page_num = intval(intval($params['page']) - 1);
-            $pag_output .= $this->lcp_page_link($this->prev_page_num , $params['page'], $params['instance'], $params['previous'] );
+            $pag_output .= $this->lcp_page_link($this->prev_page_num , $params['page'], $params['instance'],
+                                                $params['previous'], $params['bookmarks']);
           }
 
           $pag_output .= $lcp_paginator;
@@ -53,7 +55,8 @@ class LcpPaginator {
           // Add "Next" link
           if ($params['page'] < $pages_count){
             $this->next_page_num = intval($params['page'] + 1);
-            $pag_output .= $this->lcp_page_link($this->next_page_num, $params['page'], $params['instance'], $params['next']);
+            $pag_output .= $this->lcp_page_link($this->next_page_num, $params['page'],
+                                                $params['instance'], $params['next'], $params['bookmarks']);
           }
 
           $pag_output .= "</ul>";
@@ -64,7 +67,7 @@ class LcpPaginator {
 
 
   // `char` is the string from pagination_prev/pagination_next
-  private function lcp_page_link($page, $current_page, $lcp_instance, $char = null){
+  private function lcp_page_link($page, $current_page, $lcp_instance, $char = null, $bookmark){
     $link = '';
 
     if ($page == $current_page){
@@ -85,8 +88,11 @@ class LcpPaginator {
       }
       $http_host = $server_vars['HTTP_HOST'];
       $page_link = "$protocol://$http_host$url?$query" .
-                   $amp . "lcp_page" . $lcp_instance . "=". $page .
-                   "#lcp_instance_" . $lcp_instance;
+                   $amp . "lcp_page" . $lcp_instance . "=". $page;
+
+      // Append a bookmark if not disabled by 'pagination_bookmarks=no'
+      if ($bookmark !== "no") $page_link .= "#lcp_instance_" . $lcp_instance;
+
       $link .=  "<li><a href='$page_link' title='$page'";
       if ($page === $this->prev_page_num) {
           $link .= " class='lcp_prevlink'";

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -143,6 +143,7 @@ class ListCategoryPosts{
                              'before_month' => '',
                              'before_day' => '',
                              'tags_as_class' => 'no',
+                             'pagination_bookmarks' => '',
                            ), $atts);
     if($atts['numberposts'] == ''){
       $atts['numberposts'] = get_option('numberposts');

--- a/tests/lcppaginator/test-getPagination.php
+++ b/tests/lcppaginator/test-getPagination.php
@@ -1,21 +1,22 @@
 <?php
 
 class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
-   
+
     // Spoof params lcp_page_link requires to work
     protected $test_params = array(
         'posts_count' => '6',
         'numberposts' => '2',
-        'page' => 1,
-        'instance' => '0',
-        'next' => '>>',
-        'previous' => '<<'
+        'page'        => 1,
+        'instance'    => '0',
+        'next'        => '>>',
+        'previous'    => '<<',
+        'bookmarks'   => ''
     );
 
     public static function wpSetUpBeforeClass($factory) {
         // Insert 6 random posts into the test db
         $factory->post->create_many(6);
-            
+
         // Spoof QUERY_STRING becuase URL rewriting is off
         // and lcp_page_link directly accesses it (avoid 'undefined index')
         $_SERVER['QUERY_STRING'] = '';
@@ -63,6 +64,22 @@ class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
                       "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1'>1</a></li>" .
                       "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2'>2</a></li>" .
                       "<li class='lcp_currentpage'>3</li>" .
+                      "</ul>";
+        $this->assertSame($exp_string, $pag_string);
+    }
+
+    public function test_bookmarks() {
+        $paginator = LcpPaginator::get_instance();
+
+        $params = array_merge($this->test_params,
+                              array('pagination' => 'yes', 'bookmarks' => 'no'));
+        $pag_string = $paginator->get_pagination($params);
+
+        $exp_string = "<ul class='lcp_paginator'>" .
+                      "<li class='lcp_currentpage'>1</li>" .
+                      "<li><a href='http://example.org?lcp_page0=2' title='2'>2</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=3' title='3'>3</a></li>" .
+                      "<li><a href='http://example.org?lcp_page0=2' title='2' class='lcp_nextlink'>>></a></li>" .
                       "</ul>";
         $this->assertSame($exp_string, $pag_string);
     }


### PR DESCRIPTION
Pagination links are automatically appended with bookmarks to the list they are part of, i.e. lcp_instance. While this is desirable by many users, it can cause a real mess in many (badly written 😉 ) themes and plugins. So I'm proposing to introduce `pagination_bookmarks` shortcode parameter. If present and set to `no` the plugin won't append bookmarks to pagination URLs.

Default (current) example link
`http://example.org?lcp_page0=2#lcp_instance_0`

With `pagination_bookmarks=no`
`http://example.org?lcp_page0=2`

Fixes #225, fixes #291

There were also many support questions on WP Forum, like [this one](https://wordpress.org/support/topic/pagination-links-scroll-to-top-of-same-page/) or [one from today](https://wordpress.org/support/topic/issue-with-pagination-and-loading-slider-revolution/)