### PR TITLE
Improve restoring main query

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -53,6 +53,8 @@ class CatList{
     global $wp_query;
     if ( isset($wp_query) ) {
       $this->saved_wp_query = clone $wp_query;
+      global $post;
+      $this->saved_post = $post;
     }
   }
 
@@ -63,6 +65,8 @@ class CatList{
     global $wp_query;
     if ( isset($this->saved_wp_query) ) {
       $wp_query = clone $this->saved_wp_query;
+      global $post;
+      $post = $this->saved_post;
     }
   }
 


### PR DESCRIPTION
In some rare cases wp_reset_query fails to reset global `$post`
to its initial value. This manual reset ensures the plugin leaves
the main query in a clean state regardless of circumstances

https://wordpress.org/support/topic/your-plugin-has-a-crazy-bug-conflict-with-elementor/#post-10145793
Fixes #320