### PR TITLE
Display all posts except today's

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -85,7 +85,7 @@ class LcpParameters{
     }
 
     if ( $this->utils->lcp_not_empty('before') ) {
-      if('today' === strtolower($params['before']) {
+      if('today' === strtolower($params['before'])) {
           $this->before = date("Y/m/d");
       } else {
           $this->before = $params['before'];

--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -85,7 +85,7 @@ class LcpParameters{
     }
 
     if ( $this->utils->lcp_not_empty('before') ) {
-      if(strcmp(strtolower($params['before']), "today") == 0) {
+      if('today' === strtolower($params['before']) {
           $this->before = date("Y/m/d");
       } else {
           $this->before = $params['before'];

--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -85,7 +85,11 @@ class LcpParameters{
     }
 
     if ( $this->utils->lcp_not_empty('before') ) {
-      $this->before = $params['before'];
+      if(strcmp(strtolower($params['before']), "today") == 0) {
+          $this->before = date("Y/m/d");
+      } else {
+          $this->before = $params['before'];
+      }
       $date_query = true;
     }
 


### PR DESCRIPTION
`[catlist before=today]`

When I wanted to create a custom archive page for one of my projects, I hardcoded the query because neither there was a way to pass a dynamic date argument nor an option to display past posts through catlist. By this change, the plugin will get today's date dynamically and display only old posts. I believe this small change will be life saver for others too :)