### PR TITLE
Current category

### DIFF
--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -59,14 +59,21 @@ class LcpCategory{
   }
 
   public function current_category(){
+    // Only single post pages with assigned category and
+    // category archives have a 'current category',
+    // in all other cases no posts should be returned. (#69)
     $category = get_category( get_query_var( 'cat' ) );
     if( isset( $category->errors ) && $category->errors["invalid_term"][0] == __("Empty Term.") ){
       global $post;
-      $categories = get_the_category($post->ID);
+      // Since WP 4.9 global $post is nullified in text widgets
+      // when is_singular() is false.
+      if (is_singular()) {
+        $categories = get_the_category($post->ID);
+      }
       if ( !empty($categories) ){
         return $categories[0]->cat_ID;
       } else {
-        return;
+        return [0]; // workaround to display no posts
       }
     }
     return $category->cat_ID;

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -84,7 +84,8 @@ class ListCategoryPostsWidget extends WP_Widget{
 
     // Fetch the category id from the Catlist instance.
     $category_id = $catlist_displayer->catlist->get_category_id();
-    if ($category_id === null && ($title == 'catlink' || $title == 'catname')) {
+    if ((is_null($category_id) || [0] === $category_id ) &&
+        ($title == 'catlink' || $title == 'catname')) {
       $title = '';
     } elseif ($title == 'catlink') {
       // If the user has setup 'catlink' as the title, replace it with

--- a/readme.txt
+++ b/readme.txt
@@ -73,7 +73,7 @@ The plugin can figure out the category from which you want to list posts in seve
 * The *category name or slug*.
   * **name** - To display posts from a category using the category's name or slug. Ex: `[catlist name=mycategory]`
 * *Detecting the current post's category*. You can use the *categorypage* parameter to make it detect the category id of the current post, and list posts from that category.
-  * **categorypage** - Set it to "yes" if you want to list the posts from the current post's category. `[catlist categorypage="yes"]`
+  * **categorypage** - Set it to "yes" if you want to list the posts from the current post's category. `[catlist categorypage="yes"]` This will not work on pages that don't have a category: home page, author archive, date archive, etc. -- the plugin will display no posts in these cases. You can handle this with the `no_posts_text` parameter.
 
 When using List Category Posts whithout a category id, name or slug, it will post the latest posts from **every category**.
 

--- a/tests/lcpcategory/test-currentCategory.php
+++ b/tests/lcpcategory/test-currentCategory.php
@@ -64,9 +64,30 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to('/?page_id=' . self::$test_page);
     $this->assertQueryTrue('is_singular', 'is_page');
-    $this->assertSame(null, $lcpcategory->current_category());
+    $this->assertSame([0], $lcpcategory->current_category());
+  }
+
+  public function test_home_page() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to('/');
+    $this->assertQueryTrue('is_home', 'is_front_page');
+    $this->assertSame([0], $lcpcategory->current_category());
+  }
+
+  public function test_date_archive() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to(get_month_link('',''));
+    $this->assertQueryTrue('is_archive', 'is_date', 'is_month');
+    $this->assertSame([0], $lcpcategory->current_category());
+  }
+
+  public function test_author_archive() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to(get_author_posts_url(1));
+    $this->assertQueryTrue('is_archive', 'is_author');
+    $this->assertSame([0], $lcpcategory->current_category());
   }
 }
-
-// TODO: write tests for month archives and home page, but this
-// requires changing the curent_category method so that it can handle those cases.

--- a/tests/lcpcategory/test-currentCategory.php
+++ b/tests/lcpcategory/test-currentCategory.php
@@ -1,7 +1,5 @@
 <?php
-/**
- * @runTestsInSeparateProcesses
- */
+
 class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
   protected static $test_post;

--- a/tests/lcppaginator/test-getPagination.php
+++ b/tests/lcppaginator/test-getPagination.php
@@ -24,6 +24,7 @@ class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
 
     public function test_pagination_string() {
         $paginator = LcpPaginator::get_instance();
+        $this->go_to('/');
 
         // Check first page
         $params = array_merge($this->test_params,
@@ -32,9 +33,9 @@ class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
 
         $exp_string = "<ul class='lcp_paginator'>" .
                       "<li class='lcp_currentpage'>1</li>" .
-                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2'>2</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=3#lcp_instance_0' title='3'>3</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2' class='lcp_nextlink'>>></a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=2#lcp_instance_0' title='2'>2</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=3#lcp_instance_0' title='3'>3</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=2#lcp_instance_0' title='2' class='lcp_nextlink'>>></a></li>" .
                       "</ul>";
         $this->assertSame($exp_string, $pag_string);
 
@@ -45,11 +46,11 @@ class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
         $pag_string = $paginator->get_pagination($params);
 
         $exp_string = "<ul class='lcp_paginator'>" .
-                      "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1' class='lcp_prevlink'><<</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1'>1</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=1#lcp_instance_0' title='1' class='lcp_prevlink'><<</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=1#lcp_instance_0' title='1'>1</a></li>" .
                       "<li class='lcp_currentpage'>2</li>" .
-                      "<li><a href='http://example.org?lcp_page0=3#lcp_instance_0' title='3'>3</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=3#lcp_instance_0' title='3' class='lcp_nextlink'>>></a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=3#lcp_instance_0' title='3'>3</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=3#lcp_instance_0' title='3' class='lcp_nextlink'>>></a></li>" .
                       "</ul>";
         $this->assertSame($exp_string, $pag_string);
 
@@ -60,9 +61,9 @@ class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
         $pag_string = $paginator->get_pagination($params);
 
         $exp_string = "<ul class='lcp_paginator'>" .
-                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2' class='lcp_prevlink'><<</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=1#lcp_instance_0' title='1'>1</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=2#lcp_instance_0' title='2'>2</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=2#lcp_instance_0' title='2' class='lcp_prevlink'><<</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=1#lcp_instance_0' title='1'>1</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=2#lcp_instance_0' title='2'>2</a></li>" .
                       "<li class='lcp_currentpage'>3</li>" .
                       "</ul>";
         $this->assertSame($exp_string, $pag_string);
@@ -77,9 +78,9 @@ class Tests_LcpPaginator_GetPagination extends WP_UnitTestCase {
 
         $exp_string = "<ul class='lcp_paginator'>" .
                       "<li class='lcp_currentpage'>1</li>" .
-                      "<li><a href='http://example.org?lcp_page0=2' title='2'>2</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=3' title='3'>3</a></li>" .
-                      "<li><a href='http://example.org?lcp_page0=2' title='2' class='lcp_nextlink'>>></a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=2' title='2'>2</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=3' title='3'>3</a></li>" .
+                      "<li><a href='http://example.org/?lcp_page0=2' title='2' class='lcp_nextlink'>>></a></li>" .
                       "</ul>";
         $this->assertSame($exp_string, $pag_string);
     }


### PR DESCRIPTION
Fixes #69 

This is a follow up on #292 , according to #69, when using `categorypage=yes` and there is no current category (when we are not on a single page or category archive) no posts will be displayed. Once I fixed this I was able to finish writing test cases for current category.

In the current version of the plugin if we are, say, on our home page or date archive and have LCP `categorypage=yes` in our widget, the plugin will read the category of the **last** post of current loop as current category. If we add another LCP after the first one, it will read the **first** post of current loop as current cateogory. So we then have two LCP instances showing different categories :wink:
And when we are on a single page, we will get posts from all categories.

This PR changes it so that in all of the above cases the plugin returns no posts. Users can handle it with good old `no_posts_text` which I think is very intuitive .

The tests refactor is only to speed up the tests and go around an annoying feature of PHP Unit that wouldn't always print exactly same URLs.