### PR TITLE
Fix args overwrite bug in exlude_tags

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -140,7 +140,7 @@ class LcpParameters{
     }
 
     if ( $this->utils->lcp_not_empty('exclude_tags') ){
-      $args = $this->lcp_excluded_tags($params);
+      $args = $this->lcp_excluded_tags($args);
     }
 
     // Current tags
@@ -279,7 +279,7 @@ class LcpParameters{
   }
 
   private function lcp_excluded_tags($args){
-    $excluded_tags = explode(",", $args['exclude_tags']);
+    $excluded_tags = explode(",", $this->params['exclude_tags']);
     $tag_ids = array();
     foreach ( $excluded_tags as $excluded){
       $tag_ids[] = get_term_by('slug', $excluded, 'post_tag')->term_id;


### PR DESCRIPTION
Right now instead of `$args`, `$params` are passed to `lcp_excluded_tags`. This small bug means that if a user specifies `exclude_tags` shortcode parameter, two things happen:

1. Any `$args` set and parsed above line 142 of lcp-parameters.php will be ignored, e.g. `excludeposts`, `before_year` etc.
2. A full array of  raw LCP parameters will be passed to `WP_Query`

This is fixed in this PR.

Fixes https://wordpress.org/support/topic/excludepoststhis-not-working/