### PR TITLE
Categorypage final polishing

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -9,7 +9,6 @@
  * [How do I remove the bullets from the list?](#bullets)
  * [The plugin doesn't work on servers with PHP < 5](#php5)
  * [Plugin could not be activated because it triggered a fatal error](#fatal-error)
- * [If a post has many categories, categorypage=yes only detects one of them](#categorypage)
 
 ## <a name="no_link"></a>How can I remove the hyperlink of the title of the post?
 
@@ -124,9 +123,3 @@ protected accessors. Try updating your server or using an [older version](http:/
 
 Please check:
 http://wordpress.stackexchange.com/questions/9338/list-category-posts-plugin-upgrade-fails-fatal-error/9340#9340
-
-## <a name="categorypage"></a>If a post has many categories, categorypage=yes only detects one of them
-
-This is how it works in the current implementation, there are no shortcode parameters to change this behavior.
-We have already received feature requests to make `categorypage=yes` work with multiple categories and it should be
-implemented at some stage.

--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -71,7 +71,9 @@ class LcpCategory{
         $categories = get_the_category($post->ID);
       }
       if ( !empty($categories) ){
-        return $categories[0]->cat_ID;
+        return implode(',', array_map(function($cat) {
+          return $cat->cat_ID;
+        }, $categories));
       } else {
         return [0]; // workaround to display no posts
       }

--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -58,7 +58,7 @@ class LcpCategory{
     return $lcp_category_id;
   }
 
-  public function current_category(){
+  public function current_category($mode){
     // Only single post pages with assigned category and
     // category archives have a 'current category',
     // in all other cases no posts should be returned. (#69)
@@ -71,9 +71,17 @@ class LcpCategory{
         $categories = get_the_category($post->ID);
       }
       if ( !empty($categories) ){
-        return implode(',', array_map(function($cat) {
+        $cats = array_map(function($cat) {
           return $cat->cat_ID;
-        }, $categories));
+        }, $categories);
+        // AND relationship
+        if ('all' === $mode) return $cats;
+        // OR relationship, default
+        if ('yes' === $mode || '' === $mode) return implode(',', $cats);
+        // Exclude current categories
+        if ('other' === $mode) return implode(',', array_map(function($cat) {
+          return "-$cat";
+        }, $cats));
       } else {
         return [0]; // workaround to display no posts
       }

--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -134,10 +134,12 @@ class CatList{
   private function get_lcp_category(){
     // In a category page:
     if ( $this->utils->lcp_not_empty('categorypage') &&
-         $this->params['categorypage'] == 'yes' ||
+         in_array($this->params['categorypage'], ['yes', 'all', 'other']) ||
          $this->params['id'] == -1){
       // Use current category
-      $this->lcp_category_id = LcpCategory::get_instance()->current_category();
+      $this->lcp_category_id = LcpCategory::get_instance()->current_category(
+        $this->params['categorypage']
+      );
     } elseif ( $this->utils->lcp_not_empty('name') ){
       // Using the category name:
       $this->lcp_category_id = LcpCategory::get_instance()->with_name( $this->params['name'] );

--- a/tests/lcpcategory/test-currentCategory.php
+++ b/tests/lcpcategory/test-currentCategory.php
@@ -57,7 +57,7 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
       $this->go_to('/?cat=' . $category->cat_ID);
       $this->assertQueryTrue('is_category', 'is_archive');
 
-      $this->assertSame($category->cat_ID, $lcpcategory->current_category());
+      $this->assertSame($category->cat_ID, $lcpcategory->current_category('yes'));
     }
   }
 
@@ -66,15 +66,49 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to('/?p=' . self::$test_post);
     $this->assertQueryTrue('is_singular', 'is_single');
-    $this->assertSame((string) self::$test_cat, $lcpcategory->current_category());
-    $this->assertSame('Lcp test cat', get_category($lcpcategory->current_category())->cat_name);
+    $this->assertSame((string) self::$test_cat, $lcpcategory->current_category('yes'));
+    $this->assertSame('Lcp test cat', get_category($lcpcategory->current_category('yes'))->cat_name);
 
     // More than one category
     $cat_ID_1 = self::$test_cat;
     $cat_ID_2 = self::$test_cat_2;
     $this->go_to('/?p=' . self::$test_post_2);
     $this->assertQueryTrue('is_singular', 'is_single');
-    $this->assertSame("${cat_ID_1},${cat_ID_2}", $lcpcategory->current_category());
+    $this->assertSame("${cat_ID_1},${cat_ID_2}", $lcpcategory->current_category('yes'));
+  }
+
+  public function test_all_mode() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to('/?p=' . self::$test_post_2);
+    $this->assertQueryTrue('is_singular', 'is_single');
+    $this->assertSame(
+      [self::$test_cat, self::$test_cat_2],
+      $lcpcategory->current_category('all')
+    );
+  }
+
+  public function test_other_mode() {
+    $lcpcategory = LcpCategory::get_instance();
+    $cat_ID_1 = self::$test_cat;
+    $cat_ID_2 = self::$test_cat_2;
+
+    $this->go_to('/?p=' . self::$test_post_2);
+    $this->assertQueryTrue('is_singular', 'is_single');
+    $this->assertSame(
+      "-${cat_ID_1},-${cat_ID_2}",
+      $lcpcategory->current_category('other')
+    );
+  }
+
+  public function test_empty_string_equals_yes_mode() {
+    $lcpcategory = LcpCategory::get_instance();
+
+    $this->go_to('/?p=' . self::$test_post);
+    $this->assertSame(
+      $lcpcategory->current_category('yes'),
+      $lcpcategory->current_category('')
+    );
   }
 
   public function test_single_page_with_no_categories() {
@@ -82,7 +116,7 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to('/?page_id=' . self::$test_page);
     $this->assertQueryTrue('is_singular', 'is_page');
-    $this->assertSame([0], $lcpcategory->current_category());
+    $this->assertSame([0], $lcpcategory->current_category('yes'));
   }
 
   public function test_home_page() {
@@ -90,7 +124,7 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to('/');
     $this->assertQueryTrue('is_home', 'is_front_page');
-    $this->assertSame([0], $lcpcategory->current_category());
+    $this->assertSame([0], $lcpcategory->current_category('yes'));
   }
 
   public function test_date_archive() {
@@ -98,7 +132,7 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to(get_month_link('',''));
     $this->assertQueryTrue('is_archive', 'is_date', 'is_month');
-    $this->assertSame([0], $lcpcategory->current_category());
+    $this->assertSame([0], $lcpcategory->current_category('yes'));
   }
 
   public function test_author_archive() {
@@ -106,6 +140,6 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to(get_author_posts_url(1));
     $this->assertQueryTrue('is_archive', 'is_author');
-    $this->assertSame([0], $lcpcategory->current_category());
+    $this->assertSame([0], $lcpcategory->current_category('yes'));
   }
 }

--- a/tests/lcpcategory/test-currentCategory.php
+++ b/tests/lcpcategory/test-currentCategory.php
@@ -3,8 +3,10 @@
 class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
   protected static $test_post;
+  protected static $test_post_2;
   protected static $test_page;
   protected static $test_cat;
+  protected static $test_cat_2;
 
   public static function wpSetUpBeforeClass($factory) {
     // Create some random categories
@@ -18,15 +20,26 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
       ));
     }
 
-    // Create test category, test post and test page (no categories for page)
+    // Create test categories, test posts and test page (no categories for page)
     self::$test_cat = $factory->term->create(array(
       'taxonomy' => 'category',
       'name' => 'Lcp test cat'
     ));
 
+    self::$test_cat_2 = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name' => 'Lcp test cat 2'
+    ));
+
     self::$test_post = $factory->post->create(array(
       'post_title' => 'Lcp test post',
       'post_category' => array(self::$test_cat)
+    ));
+
+    // Post with 2 categories
+    self::$test_post_2 = $factory->post->create(array(
+      'post_title' => 'Lcp test post',
+      'post_category' => array(self::$test_cat, self::$test_cat_2)
     ));
 
     self::$test_page = $factory->post->create(array(
@@ -53,8 +66,15 @@ class Tests_LcpCategory_CurrentCategory extends WP_UnitTestCase {
 
     $this->go_to('/?p=' . self::$test_post);
     $this->assertQueryTrue('is_singular', 'is_single');
-    $this->assertSame(self::$test_cat, $lcpcategory->current_category());
+    $this->assertSame((string) self::$test_cat, $lcpcategory->current_category());
     $this->assertSame('Lcp test cat', get_category($lcpcategory->current_category())->cat_name);
+
+    // More than one category
+    $cat_ID_1 = self::$test_cat;
+    $cat_ID_2 = self::$test_cat_2;
+    $this->go_to('/?p=' . self::$test_post_2);
+    $this->assertQueryTrue('is_singular', 'is_single');
+    $this->assertSame("${cat_ID_1},${cat_ID_2}", $lcpcategory->current_category());
   }
 
   public function test_single_page_with_no_categories() {


### PR DESCRIPTION
Perhaps also worth adding to 1.0. Contains features requested on support forums.

Changed:
* `categorypage=yes` will get *all* post's categories with OR relationship

Added:
* `categorypage=all` for AND relationship
* `categorypage=other` to get all categories except current categories (with OR relationship, of course)