### PR TITLE
Update testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.pydevproject
 .project
 .metadata
-bin/
 tmp/
 *.tmp
 *.bak
@@ -53,7 +52,8 @@ nbproject/
 # SVN
 .svn
 
+# Vagrant
 .vagrant/
 vagrant
-
-ubuntu-xenial-16.04-cloudimg-console.log
+wordpress/
+ubuntu*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,28 @@ language: php
 # Versions of PHP to test against
 php:
   - 5.4
-  - 7.0
+  - 7.2
 
-# Specify versions of WordPress to test against
-# WP_VERSION = WordPress version number (or "latest")
-# WP_MULTISITE = whether to test multisite (use either "0" or "1")
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=latest WP_MULTISITE=1
+  global:
+    - WP_TESTS_DIR=/tmp/wordpress-tests-lib
+  # Specify versions of WordPress to test against
+  # WP_VERSION = WordPress version number (or "latest")
+  # WP_MULTISITE = whether to test multisite (use either "0" or "1")
+  matrix:
+    - WP_VERSION=latest WP_MULTISITE=0
+    - WP_VERSION=latest WP_MULTISITE=1
 
+# Use PHPUnit 6 instead of PHPUnit 7 which Travis loads by default
+# with PHP 7.2. WordPress doesn't support PHPUnit 7.
 before_script:
+  - if [[ "$TRAVIS_PHP_VERSION" == "7.2" ]]; then wget -O phpunit https://phar.phpunit.de/phpunit-6.phar; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == "7.2" ]]; then chmod a+x phpunit; fi
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
-script: WP_TESTS_DIR=/tmp/wordpress-tests-lib phpunit
+script:
+  - if [[ "$TRAVIS_PHP_VERSION" != "7.2" ]]; then phpunit; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == "7.2" ]]; then ./phpunit; fi
 
 # Reduce mail notifications by Travis CI to a minimum
 notifications:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ If you know PHP and would like to start contributing to the plugin, let me know!
 
 A Vagrantfile is provided to set up a box for WordPress development. You need [Vagrant](http://www.vagrantup.com/) installed on your computer.
 
-Fork the repo, clone it locally and do `vagrant up`. You'll have a WordPress instance running on http://127.0.0.1:8080/.
+Fork the repo, clone it locally and do `vagrant up` (on Windows you need to run this command in PowerShell as administrator).
+You'll have a WordPress instance running on http://127.0.0.1:8080/.
 
 WordPress is installed with this information:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,15 @@
 
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/xenial64"
-  config.vm.provision :shell, :path => "bootstrap.sh"
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.provision :shell, :path => "bin/bootstrap.sh"
   config.vm.network :forwarded_port, guest: 80, host: 8080
+
+  # Remove the wordpress directory after destroy command.
+  config.trigger.after :destroy do |trigger|
+    trigger.warn = "Removing 'wordpress' directory"
+    trigger.run = {inline: "rm -rf wordpress"}
+  end
 
 
   # The url from where the 'config.vm.box' box will be fetched if it
@@ -25,7 +31,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "./wordpress", "/var/www", create: true
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Update the system and install SVN + PHP7.0 + MySQL 5.7
+# Update the system and install SVN + PHP7.2 + MySQL 5.7
 if [ ! -x /usr/bin/mysql ];
 then
     sudo debconf-set-selections <<< 'mysql-server-5.7 mysql-server/root_password password rootpass'
@@ -8,7 +8,8 @@ then
 
     apt-get update
 
-    apt-get install -y subversion apache2 php7.0 php7.0-xml libapache2-mod-php7.0 mysql-server-5.7 php7.0-mysql
+    apt-get install -y subversion apache2 php7.2 php7.2-xml php7.2-mysql\
+        php7.2-gd libapache2-mod-php7.2 mysql-server-5.7
 fi
 
 # Create the WordPress database and corresponding user
@@ -40,7 +41,7 @@ fi
 if [ ! -x /usr/local/bin/wp ];
 then
     cd /usr/local/bin
-    wget -O wp https://raw.github.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+    wget -O wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
     chmod a+x wp
 fi
 
@@ -52,6 +53,8 @@ then
     sudo chown www-data:www-data .
     sudo -u www-data wp core download
     sudo -u www-data wp core config --dbname=wordpress --dbuser=wordpressuser --dbpass=wordpresspass
+    sudo -u www-data wp config set WP_DEBUG true --type=constant
+    sudo -u www-data wp config set WP_DEBUG_LOG true --type=constant
     sudo -u www-data wp core install --url="http://localhost:8080" --title="Testing the LCP plugin" --admin_user=adminuser --admin_password=adminpass --admin_email="admin@example.com"
     sudo -u www-data wp plugin install wordpress-importer --activate
     sudo -u www-data wget https://raw.githubusercontent.com/manovotny/wptest/master/wptest.xml
@@ -65,7 +68,7 @@ fi
 if [ ! -x /usr/local/bin/phpunit ];
 then
     cd /usr/local/bin
-    wget -O phpunit https://phar.phpunit.de/phpunit.phar
+    wget -O phpunit https://phar.phpunit.de/phpunit-6.phar
     chmod a+x phpunit
 fi
 
@@ -73,5 +76,5 @@ fi
 if [ -x /usr/local/bin/phpunit -a -f /var/www/wordpress ];
 then
     cd /var/www/wp-content/plugins/list-category-posts
-    sudo -u www-data WP_TESTS_DIR=/var/www/wp-tests-lib/includes WP_CORE_DIR=/var/www/ bash bin/install-wp-tests.sh wordpress_test root rootpass localhost latest
+    sudo -u www-data WP_TESTS_DIR=/var/www/wp-tests-lib WP_CORE_DIR=/var/www/ bash bin/install-wp-tests.sh wordpress_test root rootpass localhost latest
 fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -11,8 +11,9 @@ DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib/includes}
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib/}
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+WP_TESTS_INCLUDES_DIR=$WP_TESTS_DIR/includes/
 
 set -ex
 
@@ -53,22 +54,22 @@ install_test_suite() {
 	fi
 
 	# set up testing suite if it doesn't yet exist
-	if [ ! "$(ls -A $WP_TESTS_DIR)" ]; then
+	if [ ! "$(ls -A $WP_TESTS_INCLUDES_DIR)" ]; then
 		# set up testing suite
-		mkdir -p $WP_TESTS_DIR
-		svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/ $WP_TESTS_DIR
-		svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/data/ $WP_TESTS_DIR/../data
+		mkdir -p $WP_TESTS_INCLUDES_DIR
+		svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/ $WP_TESTS_INCLUDES_DIR
+		svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
-	cd $WP_TESTS_DIR
+	cd $WP_TESTS_INCLUDES_DIR
 
 	if [ ! -f wp-tests-config.php ]; then
-		download https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
-		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
-		sed $ioption "s/yourusernamehere/$DB_USER/" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
-		sed $ioption "s|localhost|${DB_HOST}|" $(dirname ${WP_TESTS_DIR})/wp-tests-config.php
+		download https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php $(dirname ${WP_TESTS_INCLUDES_DIR})/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" $(dirname ${WP_TESTS_INCLUDES_DIR})/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" $(dirname ${WP_TESTS_INCLUDES_DIR})/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" $(dirname ${WP_TESTS_INCLUDES_DIR})/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" $(dirname ${WP_TESTS_INCLUDES_DIR})/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" $(dirname ${WP_TESTS_INCLUDES_DIR})/wp-tests-config.php
 	fi
 
 }


### PR DESCRIPTION
Changed:
* Vagrant:
  * ubuntu/xenial64 -> ubuntu/bionic64
  * PHP 7.0 -> PHP 7.2
  * Instead of fetching latest PHPUnit, fetch PHPUnit 6 because later versions are not supported by WordPress
* Travis:
  * PHP 7.0 -> PHP 7.2
  * Conditionally install and run PHPUnit 6 when running PHP 7.2 because Travis would use PHPUnit 7 which is not supported by WordPress
* Tests setup:
  * `WP_TESTS_DIR` now points to the same directory in all bash scripts.
  * moved `bootstrap.sh` to `bin/bootstrap.sh`

Added:
* Vagrant:
  * `vagrant up` will create a `wordpress` directory and sync it with WP instance on the Vagrant box. This will make editing theme files and custom templates easier.
  * `php-gd` package, in case someone wanted to do image resizing for thumbnails
  * `WP_DEBUG` and `WP_DEBUG_LOG`, both set to `true`
  * a trigger that runs after `vagrant destroy` to remove the `wordpress` directory, doesn't work on Windows.
* Tests setup: `WP_TESTS_INCLUDES_DIR` is used where formerly `WP_TESTS_DIR` pointed to `includes/` subdir

Resolves #224
