### PR TITLE
Fix current category for posts displayed in the loop.

### DIFF
--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -65,9 +65,13 @@ class LcpCategory{
     $category = get_category( get_query_var( 'cat' ) );
     if( isset( $category->errors ) && $category->errors["invalid_term"][0] == __("Empty Term.") ){
       global $post;
-      // Since WP 4.9 global $post is nullified in text widgets
-      // when is_singular() is false.
-      if (is_singular()) {
+      /* Since WP 4.9 global $post is nullified in text widgets
+       * when is_singular() is false.
+       *
+       * Added in_the_loop check to make the shortcode work
+       * in posts listed in archives and home page (#358).
+       */
+      if ( is_singular() || in_the_loop() ) {
         $categories = get_the_category($post->ID);
       }
       if ( !empty($categories) ){


### PR DESCRIPTION
When posts are displayed in the Loop, for example on the home page or archive, LCP shortcodes using `categorypage` in those posts will show no links. I introduced this bug in #327 because I completely forgot about this use case 😉 

Thanks @Coxworld for reporting this.

Fixes #358 