### PR TITLE
Allow to include posts by ID (resolve #310)

### DIFF
--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -43,6 +43,11 @@ class LcpParameters{
     // Check posts to exclude
     $args = $this->lcp_check_excludes($args);
 
+    // Check posts to include
+    if( $this->utils->lcp_not_empty('includeposts') ){
+      $args['post__in'] = explode(",", $this->params['includeposts']);
+    }
+
     // Check type, status, parent params
     $args = $this->lcp_types_and_statuses($args);
 

--- a/include/lcp-widget-form.php
+++ b/include/lcp-widget-form.php
@@ -16,6 +16,7 @@
                     'excerpt_size' =>'',
                     'exclude'=>'',
                     'excludeposts'=>'',
+                    'includeposts'=>'',
                     'thumbnail' =>'',
                     'thumbnail_size' =>'',
                     'offset'=>'',
@@ -37,6 +38,7 @@
   $showauthor = strip_tags($instance['show_author']);
   $exclude = strip_tags($instance['exclude']);
   $excludeposts = strip_tags($instance['excludeposts']);
+  $includeposts = strip_tags($instance['includeposts']);
   $offset = strip_tags($instance['offset']);
   $showcatlink = strip_tags($instance['show_catlink']);
   $categoryid = strip_tags($instance['categoryid']);
@@ -164,6 +166,16 @@
   <input id="<?php echo $this->get_field_id('excludeposts'); ?>"
     name="<?php echo $this->get_field_name('excludeposts'); ?>" type="text"
     value="<?php echo esc_attr($excludeposts); ?>" />
+</p>
+
+<p>
+  <label for="<?php echo $this->get_field_id('includeposts'); ?>">
+    <?php _e("Include posts (id's)", 'list-category-posts')?>
+  </label>
+  <br/>
+  <input id="<?php echo $this->get_field_id('includeposts'); ?>"
+    name="<?php echo $this->get_field_name('includeposts'); ?>" type="text"
+    value="<?php echo esc_attr($includeposts); ?>" />
 </p>
 
 <p>

--- a/include/lcp-widget.php
+++ b/include/lcp-widget.php
@@ -25,6 +25,8 @@ class ListCategoryPostsWidget extends WP_Widget{
       $excludeposts = $post->ID;
     if(!isset($excludeposts))
       $excludeposts = ($instance['excludeposts'] != '') ? $instance['excludeposts'] : 0;
+    if(!isset($includeposts))
+      $includeposts = ($instance['includeposts'] != '') ? $instance['includeposts'] : 0;
     $offset = (is_numeric($instance['offset'])) ? $instance['offset'] : 0;
     $category_id = $instance['categoryid'];
     $dateformat = ($instance['dateformat']) ? $instance['dateformat'] : get_option('date_format');
@@ -58,6 +60,7 @@ class ListCategoryPostsWidget extends WP_Widget{
       'excerpt_size' => $excerptsize,
       'exclude' => $exclude,
       'excludeposts' => $excludeposts,
+      'includeposts' => $includeposts,
       'offset' => $offset,
       'catlink' => $showcatlink,
       'thumbnail' => $thumbnail,
@@ -114,6 +117,7 @@ class ListCategoryPostsWidget extends WP_Widget{
     $instance['order'] = strip_tags($new_instance['order']);
     $instance['exclude'] = strip_tags($new_instance['exclude']);
     $instance['excludeposts'] = strip_tags($new_instance['excludeposts']);
+    $instance['includeposts'] = strip_tags($new_instance['includeposts']);
     $instance['offset'] = strip_tags($new_instance['offset']);
     $instance['categoryid'] = strip_tags($new_instance['categoryid']);
     $instance['dateformat'] = strip_tags($new_instance['dateformat']);

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -63,6 +63,7 @@ class ListCategoryPosts{
         'excerpt_class' =>'',
         'exclude' => '0',
         'excludeposts' => '0',
+        'includeposts' => '0',
         'offset' => '0',
         'tags' => '',
         'exclude_tags' => '',


### PR DESCRIPTION
This PR adds a `includeposts` parameter that allows to list selected posts/pages by ID. Also adds the corresponding option in the widget form.

Example usage:

[catlist post_type="page" includeposts="2,97" content="full"]
