### PR TITLE
Improve LcpCategory

### DIFF
--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -118,9 +118,9 @@ class LcpCategory{
    *                          array for 'and' relationship.
    */
   public function with_name($name) {
-    if (preg_match('/\+/', $name) ) { // AND relationship
+    if (false !== strpos($name, '+')) { // AND relationship
       return $this->and_relationship($name);
-    } elseif (preg_match('/,/', $name )) { // OR relationship
+    } elseif (false !== strpos($name, ',')) { // OR relationship
       return $this->or_relationship($name);
     }
     return $this->get_category_id_by_name($name);

--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -98,14 +98,13 @@ class LcpCategory{
   }
 
   private function or_relationship($name) {
-    $categories = '';
+    $categories = array();
     $catArray = explode(",", $name);
 
     foreach ($catArray as $category){
-      $id = $this->get_category_id_by_name($category);
-      $categories .= $id . ",";
+      $categories[] = $this->get_category_id_by_name($category);
     }
 
-    return $categories;
+    return implode(',',$categories);
   }
 }

--- a/include/lcp-category.php
+++ b/include/lcp-category.php
@@ -15,11 +15,32 @@ class LcpCategory{
     return self::$instance;
   }
 
-  public function get_lcp_category($params, &$lcp_category_id) {
+  /**
+   * Parses category related shortcode parameters and returns
+   * WP_Query compatible $args array. Also sets $lcp_category_id.
+   *
+   * This method is the main interface of the LcpCategory class. It
+   * is currently only used by the CatList class and servers as its helper.
+   * $params expects all category related shortcode parameters.
+   * $lcp_category_id is **passed by reference** so that it can be
+   * changed here. CatList::$lcp_category_id relies on this value heavily.
+   *
+   * @param  array  $params {
+   *   Category related shortcode parameter values.
+   *
+   *   @type string $id
+   *   @type string $name
+   *   @type string $categorypage
+   *   @type string $child_categories
+   * }
+   * @param  mixed  &$lcp_category_id Optional. Updated by this method if necessary.
+   * @return array                    WP_Query $args array, @see lcp_categories.
+   */
+  public function get_lcp_category($params, &$lcp_category_id=0) {
     // Only used when excluded categories are combined with 'and' relationship.
     $exclude = [];
     // This will be the value of lcp_category_id which is passed by reference.
-    $categories = 0;
+    $categories = $lcp_category_id;
 
     // In a category page:
     if ($params['categorypage'] &&
@@ -48,8 +69,21 @@ class LcpCategory{
   }
 
   /**
-   * Check if there's one or more categories.
-   * Used in the beginning when setting up the parameters.
+   * Formats the $args array in compliance with WP_Query.
+   *
+   * This method assigns input category IDs to proper WP_Query $args array.
+   * $categories expects an int, string or an array following the logic:
+   * - int    -> single category
+   * - array  -> 'and' relationship
+   * - string -> 'or' relationship (or single cateogry as a string)
+   *
+   * $child_categories is the value of `child_categories` shortcode param.
+   * $exclude is only used when combining 'and' relationship with excluded IDs.
+   *
+   * @param  int|string|array $categories       Category IDs.
+   * @param  string           $child_categories 'no' or 'false' disables child cats.
+   * @param  array            $exclude          Accepts an array of IDs.
+   * @return array                              WP_Query $args array.
    */
   private function lcp_categories($categories, $child_categories, $exclude) {
     $args = array();
@@ -68,18 +102,44 @@ class LcpCategory{
     return $args;
   }
 
-  /*
-   * When the category is set using the `name` parameter.
+  /**
+   * Used when the category is set using the `name` shortcode parameter.
+   *
+   * This method returns a category ID when a single category is specified,
+   * a string containing comma separated category IDs when using the 'or'
+   * relationship, an array of category IDs when using the 'and' relationship.
+   *
+   * If $name does not resolve to an existing name or slug, `0` will be returned.
+   * Similarly, the returned comma separated string or an array will have `0`
+   * for any name/slug that could not be found.
+   *
+   * @param  string $name     Accepts valid `name` shortcode parameter values.
+   * @return int|string|array Int for single category, string for 'or' relationsip,
+   *                          array for 'and' relationship.
    */
-  public function with_name($name){
-    if ( preg_match('/\+/', $name) ){ // AND relationship
+  public function with_name($name) {
+    if (preg_match('/\+/', $name) ) { // AND relationship
       return $this->and_relationship($name);
-    } elseif (preg_match('/,/', $name )){ // OR relationship
+    } elseif (preg_match('/,/', $name )) { // OR relationship
       return $this->or_relationship($name);
     }
     return $this->get_category_id_by_name($name);
   }
 
+  /**
+   * Used when the category is set using the `id` shortcode parameter.
+   *
+   * Accepts all valid `id` parameter values. If $cat_id is a single category
+   * ID or comma separated IDs (for the 'or' relationship), this method does not
+   * perfom any parsing and returns the string as is. If the 'and' relationship
+   * is used (eg. `id=1+2+3`), returns an array of IDs. If the 'and' relationship is
+   * used together with excluded categories (`id=1+2-3-4`), returns an array of
+   * included IDs that also contains the 'exclude' key that is an array of excluded
+   * IDs.
+   *
+   * @param  string $name Accepts valid `id` shortcode parameter values.
+   * @return string|array Array of IDs for 'and' relationship, string otherwise.
+   */
   public function with_id($cat_id) {
     if (false !== strpos($cat_id, '+')) {
       if (false !== strpos($cat_id, '-')) {
@@ -91,7 +151,7 @@ class LcpCategory{
         preg_match('/(?P<in>(\+?[0-9]+)+)(?P<ex>(-[0-9]+)+)/', $cat_id, $matches);
 
         $cat_id = array_map('intval', explode("+", $matches['in']));
-        $cat_id['exclude'] = implode(',', explode('-', ltrim($matches['ex'], '-')));
+        $cat_id['exclude'] = explode('-', ltrim($matches['ex'], '-'));
       } else {
         // Simple 'and' relationship, just convert input into an array.
         $cat_id = array_map('intval', explode("+", $cat_id));
@@ -101,6 +161,19 @@ class LcpCategory{
     return $cat_id;
   }
 
+  /**
+   * Handles the `categorypage` shortcode parameter with all its modes.
+   *
+   * This method accepts all valid `categorypage` shortcode parameters.
+   * Also accepts an empty string for compatibility with the widget.
+   * Returns a single category ID when used on category archive page,
+   * a comma separated string of IDs for the 'or' relationship,
+   * an array of IDs for the 'and' relationship. When no posts should be
+   * displayed it returns `[0]`.
+   *
+   * @param  string $mode     Accepts 'all', 'yes', 'other' and empty string.
+   * @return int|string|array Category ID(s).
+   */
   public function current_category($mode){
     // Only single post pages with assigned category and
     // category archives have a 'current category',
@@ -138,34 +211,55 @@ class LcpCategory{
 
 
   /**
-   * Get the category id from its name
-   * by Eric Celeste / http://eric.clst.org
+   * Gets the category id from its name.
+   *
+   * @author Eric Celeste / http://eric.clst.org
+   *
+   * @param   string $category_name Accepts category name or slug.
+   * @return  int                   Category ID or 0 if none found.
    */
-  private function get_category_id_by_name($category_name){
-    //TODO: Support multiple names (this used to work, but not anymore)
-    //We check if the name gets the category id, if not, we check the slug.
+  private function get_category_id_by_name($category_name) {
+    //We check if the slug gets the category id, if not, we check the name.
     $term = get_term_by('slug', $category_name, 'category');
-    if (!$term){
+    if (!$term) {
       $term = get_term_by('name', $category_name, 'category');
     }
     return ($term) ? $term->term_id : 0;
   }
 
-  private function and_relationship($name){
+  /**
+   * Handles 'and' relationship when categories are specified by name.
+   *
+   * Parses the input string and returns an array of corresponding
+   * category IDs.
+   *
+   * @param  string $name Accepts category names or slugs separated by the '+' sign.
+   * @return array        Category IDs.
+   */
+  private function and_relationship($name) {
     $categories = array();
     $cat_array = explode("+", $name);
 
-    foreach ($cat_array as $category){
+    foreach ($cat_array as $category) {
       $categories[] = $this->get_category_id_by_name($category);
     }
     return $categories;
   }
 
+  /**
+   * Handles 'or' relationship when categories are specified by name.
+   *
+   * Parses the input string and returns comma separated
+   * category IDs.
+   *
+   * @param  string $name Accepts category names or slugs separated by the ',' sign.
+   * @return string       Comma separated category IDs.
+   */
   private function or_relationship($name) {
     $categories = array();
     $catArray = explode(",", $name);
 
-    foreach ($catArray as $category){
+    foreach ($catArray as $category) {
       $categories[] = $this->get_category_id_by_name($category);
     }
 

--- a/tests/lcpcategory/test-getLcpCategory.php
+++ b/tests/lcpcategory/test-getLcpCategory.php
@@ -1,0 +1,197 @@
+<?php
+
+class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
+
+  private static $instance;
+  private static $test_cat;
+  private static $test_cat_2;
+
+  public static function wpSetUpBeforeClass($factory) {
+
+    self::$test_cat = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name'     => 'Dogs'
+    ));
+    self::$test_cat_2 = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name'     => 'Cats'
+    ));
+
+    // Get an instance of LcpCategory.
+    self::$instance = LcpCategory::get_instance();
+  }
+
+  public function test_single_category() {
+
+    $this->assertSame(
+      ['cat' => '5'],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '5',
+          'name'             => '',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+
+    $this->assertSame(
+      ['cat' => self::$test_cat],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '',
+          'name'             => 'Dogs',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+  }
+
+  public function test_or_relationship() {
+
+    // By id.
+    $this->assertSame(
+      ['cat' => '1,2,3,4'],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '1,2,3,4',
+          'name'             => '',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+
+    $this->assertSame(
+      ['cat' => '1,-2,-3,4'],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '1,-2,-3,4',
+          'name'             => '',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+
+    // By name.
+    $this->assertSame(
+      ['cat' => self::$test_cat . ',' . self::$test_cat_2],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '',
+          'name'             => 'Dogs,Cats',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+  }
+
+  public function test_no_child_categories() {
+
+    // By id.
+    $this->assertSame(
+      ['category__in' => '1,2,3,4'],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '1,2,3,4',
+          'name'             => '',
+          'categorypage'     => '',
+          'child_categories' => 'no',
+        ]
+      )
+    );
+
+    // By name.
+    $this->assertSame(
+      ['category__in' => self::$test_cat . ',' . self::$test_cat_2],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '',
+          'name'             => 'Dogs,Cats',
+          'categorypage'     => '',
+          'child_categories' => 'no',
+        ]
+      )
+    );
+  }
+
+  public function test_and_relationship() {
+
+    // By id.
+    $this->assertSame(
+      ['category__and' => [1, 2, 3, 4]],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '1+2+3+4',
+          'name'             => '',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+
+    // By name.
+    $this->assertSame(
+      ['category__and' => [self::$test_cat, self::$test_cat_2]],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '',
+          'name'             => 'Dogs+Cats',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+  }
+
+  public function test_and_relationship_with_exlude() {
+
+    $this->assertEquals(
+      ['category__and' => [1, 2,], 'category__not_in' => [3, 4]],
+      self::$instance->get_lcp_category(
+        [
+          'id'               => '1+2-3-4',
+          'name'             => '',
+          'categorypage'     => '',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+  }
+
+  public function test_current_category() {
+
+    // Just test if shortcode param is recognised properly.
+    // Detailed tests are in another test case.
+    $this->assertSame(
+      ['category__and' => [0]],
+      self::$instance->get_lcp_category(
+        [
+          'categorypage'     => 'yes',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+    $this->assertSame(
+      ['category__and' => [0]],
+      self::$instance->get_lcp_category(
+        [
+          'categorypage'     => 'other',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+    $this->assertSame(
+      ['category__and' => [0]],
+      self::$instance->get_lcp_category(
+        [
+          'categorypage'     => 'all',
+          'child_categories' => 'yes',
+        ]
+      )
+    );
+  }
+}

--- a/tests/lcpcategory/test-withId.php
+++ b/tests/lcpcategory/test-withId.php
@@ -1,0 +1,66 @@
+<?php
+
+class Tests_LcpCategory_WithId extends WP_UnitTestCase {
+
+  private static $instance;
+
+  public static function wpSetUpBeforeClass($factory) {
+
+    // Get an instance of LcpCategory.
+    self::$instance = LcpCategory::get_instance();
+  }
+
+  public function test_single_id() {
+
+    // It should just return the argument as is.
+    $this->assertSame(
+      53,
+      self::$instance->with_id(53)
+    );
+    $this->assertSame(
+      '432',
+      self::$instance->with_id('432')
+    );
+  }
+
+  public function test_and_relationship() {
+
+    // 2 categories by id.
+    $this->assertSame(
+      [1, 2],
+      self::$instance->with_id('1+2')
+    );
+    // 3 categories by id.
+    $this->assertSame(
+      [1, 2, 3],
+      self::$instance->with_id('1+2+3')
+    );
+  }
+
+  public function test_or_relationship() {
+
+    // It should just return the argument as is.
+    $this->assertSame(
+      '1,2,3,4',
+      self::$instance->with_id('1,2,3,4')
+    );
+  }
+
+  public function test_exclude() {
+
+    // It should just return the argument as is.
+    $this->assertSame(
+      '1,-2,-3,4',
+      self::$instance->with_id('1,-2,-3,4')
+    );
+  }
+
+  public function test_and_relationship_with_exclude() {
+
+    // It should just return the argument as is.
+    $this->assertEquals(
+      [1, 2, 3, 'exclude' => [5, 6]],
+      self::$instance->with_id('1+2+3-5-6')
+    );
+  }
+}

--- a/tests/lcpcategory/test-withName.php
+++ b/tests/lcpcategory/test-withName.php
@@ -1,0 +1,100 @@
+<?php
+
+class Tests_LcpCategory_WithName extends WP_UnitTestCase {
+
+  private static $test_cat;
+  private static $test_cat_2;
+  private static $test_cat_3;
+
+  private static $instance;
+
+  public static function wpSetUpBeforeClass($factory) {
+
+    // Create test categories.
+    self::$test_cat = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name'     => 'Lcp test cat',
+      'slug'     => 'lcptest',
+    ));
+    self::$test_cat_2 = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name'     => 'Lcp test cat 2',
+      'slug'     => 'lcptest2',
+    ));
+    self::$test_cat_3 = $factory->term->create(array(
+      'taxonomy' => 'category',
+      'name'     => 'Lcp test cat 3',
+      'slug'     => 'lcptest3',
+    ));
+
+    // Get an instance of LcpCategory.
+    self::$instance = LcpCategory::get_instance();
+  }
+
+  public function test_single_name() {
+
+    // Using a name.
+    $this->assertSame(
+      self::$test_cat,
+      self::$instance->with_name('Lcp test cat')
+    );
+    // Using a slug.
+    $this->assertSame(
+      self::$test_cat,
+      self::$instance->with_name('lcptest')
+    );
+    // Non existent category.
+    $this->assertSame(
+      0,
+      self::$instance->with_name('No such category')
+    );
+  }
+
+  public function test_and_relationship() {
+
+    // 2 categories by name.
+    $this->assertSame(
+      [self::$test_cat, self::$test_cat_2],
+      self::$instance->with_name('Lcp test cat+Lcp test cat 2')
+    );
+    // 3 categories by name.
+    $this->assertSame(
+      [self::$test_cat, self::$test_cat_2, self::$test_cat_3],
+      self::$instance->with_name('Lcp test cat+Lcp test cat 2+Lcp test cat 3')
+    );
+    // 2 categories by slug.
+    $this->assertSame(
+      [self::$test_cat, self::$test_cat_2],
+      self::$instance->with_name('lcptest+lcptest2')
+    );
+    // 3 categories by slug.
+    $this->assertSame(
+      [self::$test_cat, self::$test_cat_2, self::$test_cat_3],
+      self::$instance->with_name('lcptest+lcptest2+lcptest3')
+    );
+  }
+
+  public function test_or_relationship() {
+
+    // 2 categories by name.
+    $this->assertSame(
+      self::$test_cat . ',' . self::$test_cat_2,
+      self::$instance->with_name('Lcp test cat,Lcp test cat 2')
+    );
+    // 3 categories by name.
+    $this->assertSame(
+      self::$test_cat . ',' . self::$test_cat_2 . ',' . self::$test_cat_3,
+      self::$instance->with_name('Lcp test cat,Lcp test cat 2,Lcp test cat 3')
+    );
+    // 2 categories by slug.
+    $this->assertSame(
+      self::$test_cat . ',' . self::$test_cat_2,
+      self::$instance->with_name('lcptest,lcptest2')
+    );
+    // 3 categories by slug.
+    $this->assertSame(
+      self::$test_cat . ',' . self::$test_cat_2 . ',' . self::$test_cat_3,
+      self::$instance->with_name('lcptest,lcptest2,lcptest3')
+    );
+  }
+}


### PR DESCRIPTION
I've ended up hacking more than expected 😆 

Nothing changes in how the plugin works. In this PR:
* Fix: `[catlist id=1+2-3-4]` will work again.
* Refacor: moved lcp_categories and get_lcp_category from CatList to Lcp Category, now all category related code is nicely in one class
* Code cleanup:
  - Simplified code in many places (for instance: we don't need to check if an array key is set if we know for sure it is set because it's hardcoded)
  - Improved spacing and readability
  - Added a lot of tests and documentation
  - Removed unnecessary, performance hungry calls to `preg_match()`