### PR TITLE
Fix PHP warnings caused by widget back end

### DIFF
--- a/include/lcp-templater.php
+++ b/include/lcp-templater.php
@@ -22,7 +22,7 @@ class LcpTemplater {
    *
    * @var array
    */
-  private static $paths = null;
+  private static $paths = [];
 
   /**
    * Path to the template file being used.
@@ -81,13 +81,15 @@ class LcpTemplater {
    * @return array Paths to template directory.
    */
   private static function get_template_paths() {
-    if (null === self::$paths) {
-      self::$paths = array_unique(
+    if ([] === self::$paths) {
+      $paths = array_unique(
         [
           get_stylesheet_directory()  . '/list-category-posts/',
           get_template_directory() . '/list-category-posts/',
         ]
       );
+      $paths = array_filter($paths, 'is_dir');
+      self::$paths = $paths;
     }
     return self::$paths;
   }


### PR DESCRIPTION
When I was refactoring things in #411 I forgot that the widget admin panel scans for templates.

Re-added an `is_dir` check so that PHP doesn't complain about non existent directories.