### PR TITLE
Fix the following error messages from lcp-templater.php

### DIFF
--- a/include/lcp-templater.php
+++ b/include/lcp-templater.php
@@ -107,6 +107,10 @@ class LcpTemplater {
     $paths = self::get_template_paths();
 
     foreach ($paths as $path) {
+      if (!is_dir($path)) {
+        continue;
+      }
+
       foreach (scandir($path) as $file) {
         if (! self::validate_template($path, $file)) {
           continue;


### PR DESCRIPTION
[20-Oct-2020 18:18:25 UTC] PHP Warning:  scandir(): (errno 2): No such file or directory in wp-content/plugins/list-category-posts/include/lcp-templater.php on line 110
[20-Oct-2020 18:18:25 UTC] PHP Warning:  Invalid argument supplied for foreach() in wp-content/plugins/list-category-posts/include/lcp-templater.php on line 110