### PR TITLE
Fix posts_where filter not being properly removed when using starting_with

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -92,7 +92,7 @@ class CatList{
     global $wp_query;
     $this->posts_count = $wp_query->found_posts;
     remove_all_filters('posts_orderby');
-    remove_filter('posts_where', array( $this, 'starting_with'));
+    remove_filter('posts_where', array(LcpParameters::get_instance(), 'starting_with'));
   }
 
   /* Should I return posts or show that the tag/category or whatever


### PR DESCRIPTION
This was fixed many years ago in #145 but later the code was refactored out and the bug rose its ugly head again 🤣 

Fixes #439 