### PR TITLE
Update lcp-catlist.php to pass excerpts=full through filters

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -396,6 +396,7 @@ class CatList{
           preg_match('/[\S\s]+(<!--more(.*?)?-->)[\S\s]+/', $lcp_content, $matches)) {
           $lcp_excerpt = explode($matches[1], $lcp_content);
           $lcp_excerpt = $lcp_excerpt[0];
+          $lcp_excerpt = apply_filters('the_excerpt', $lcp_excerpt);
         } else {
           $lcp_excerpt = $this->lcp_trim_excerpt($lcp_content);
         }


### PR DESCRIPTION
Pull request to ensure that if the parameter "excerpt=full" is set, then any excerpt is sent through the normal excerpt filters (i.e. in a consistent manner as for "excerpt=yes").