### PR TITLE
Add deploy to WP action

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,16 @@
+/.wordpress-org
+/.git
+/.github
+/.distignore
+/.gitignore
+/.gitattributes
+
+LICENSE
+phpunit.xml
+README.md
+
+Vagrantfile
+
+/bin
+/doc
+/tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: list-category-posts


### PR DESCRIPTION
Hi @picandocodigo, I use[ this action](https://github.com/10up/action-wordpress-plugin-deploy) in the GUI plugin and I like how it simplifies deployment. Maybe you will find it helpful too 😃 

The `.distignore` lists files to exclude during deployment, I think I got it right but do have another look :wink:

The action automatically deploys to WP repository when a new tag is pushed. The tag in git can include a leading `v` and the action will strip it and create a direcory in `/tags` without it.

Optionally, you can also create a `.wordpress-org` directory and the action will copy its contents to svn `/assets`.

All you need to do to make it work is to add required secrets to the repository as described [in the docs](https://github.com/10up/action-wordpress-plugin-deploy#required-secrets).

