### PR TITLE
Add category_description styling

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -210,9 +210,7 @@ class CatList{
 
   public function get_category_description() {
     if ($this->utils->lcp_not_empty('category_description') && $this->params['category_description'] == 'yes') {
-      return $this->wrapper->to_html('p', [], category_description(
-        $this->lcp_category_id
-      ));
+      return get_term_field('description', $this->lcp_category_id, '', 'raw');
     }
   }
 

--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -72,8 +72,8 @@ class CatListDisplayer {
     return $this->catlist->get_category_count();
   }
 
-  public function get_category_description(){
-    return $this->catlist->get_category_description();
+  public function get_category_description($tag = null, $css_class = null) {
+    return $this->content_getter('category_description', null, $tag, $css_class);
   }
 
   private function get_no_posts_text() {
@@ -175,6 +175,9 @@ class CatListDisplayer {
       break;
     case 'customfield':
       $info = $this->catlist->get_custom_fields($this->params['customfield_display'], $post->ID);
+      break;
+    case 'category_description':
+      $info = $this->catlist->get_category_description();
       break;
     case 'date':
       $info = $this->catlist->get_date_to_show($post);

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -117,6 +117,8 @@ class ListCategoryPosts{
         'categorypage' => '',
         'category_count' => '',
         'category_description' => 'no',
+        'category_description_tag' => '',
+        'category_description_class' => '',
         'morelink' => '',
         'morelink_class' => '',
         'morelink_tag' => '',

--- a/templates/default.php
+++ b/templates/default.php
@@ -41,7 +41,7 @@ $lcp_display_output = '';
 $lcp_display_output .= $this->get_category_link('strong');
 
 // Show category description:
-$lcp_display_output .= $this->get_category_description();
+$lcp_display_output .= $this->get_category_description('p');
 
 // Show the conditional title:
 $lcp_display_output .= $this->get_conditional_title();


### PR DESCRIPTION
In addition to neccessary method updates and new shortcodes:
`category_description_tag` and `category_description_class`,
the `category_description()` function has been replaced with
the `get_term_field(`) function because the former automatically
wrapped output in `<p>` tags. The default `<p>` tag has been retained
by updating the default LCP template.

Fixes #364