### PR TITLE
Making the plugin extensible - first hooks.

### DIFF
--- a/include/lcp-paginator.php
+++ b/include/lcp-paginator.php
@@ -101,6 +101,7 @@ class LcpPaginator {
 
         $pag_output .= "</ul>";
       }
+      $pag_output = apply_filters( 'lcp_pagination_html', $pag_output, $params, $pages_count );
       return $pag_output;
     }
   }

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -160,7 +160,8 @@ class ListCategoryPosts{
    * @param $content
    */
   static function catlist_func($atts) {
-    $atts = shortcode_atts(self::default_params(), $atts);
+    // Can be filtered using the shortcode_atts_catlist hook.
+    $atts = shortcode_atts(self::default_params(), $atts, 'catlist');
 
     if($atts['numberposts'] == ''){
       $atts['numberposts'] = get_option('numberposts');


### PR DESCRIPTION
The plugin should follow WP best practices and include hooks to allow developers to interact with it.

First hooks are:
* `shortcode_atts_catlist` - a built in WP hook [documented here](https://developer.wordpress.org/reference/hooks/shortcode_atts_shortcode/).
* `lcp_pagination_html` - a custom filter hook, will be, currently, the only way to alter pagination html.