### PR TITLE
#452 support customfield data type

### DIFF
--- a/include/lcp-meta-query.php
+++ b/include/lcp-meta-query.php
@@ -89,8 +89,8 @@ trait LcpMetaQuery {
         'compare' => 'EXISTS',
       );
 
-      if( !empty($params['customfield_type']) ) {
-        $meta_query['orderby_clause']['type'] = strtoupper($params['customfield_type']);
+      if( !empty($params['customfield_orderby_type']) ) {
+        $meta_query['orderby_clause']['type'] = strtoupper($params['customfield_orderby_type']);
       }
     }
   }

--- a/include/lcp-meta-query.php
+++ b/include/lcp-meta-query.php
@@ -83,9 +83,15 @@ trait LcpMetaQuery {
    */
   private function check_customfield_orderby($params, &$meta_query) {
     if ( $params['customfield_orderby'] ) {
-      $meta_query['orderby_clause'] = array(
+		$type = 'CHAR';
+	    if(isset($params['customfield_type'])){
+	    	$type = strtoupper($params['customfield_type']);
+	    }
+
+	    $meta_query['orderby_clause'] = array(
         'key' => $params['customfield_orderby'],
         'compare' => 'EXISTS',
+        'type' => $type,
       );
     }
   }

--- a/include/lcp-meta-query.php
+++ b/include/lcp-meta-query.php
@@ -83,12 +83,14 @@ trait LcpMetaQuery {
    */
   private function check_customfield_orderby($params, &$meta_query) {
     if ( $params['customfield_orderby'] ) {
-		$type = 'CHAR';
-	    if(isset($params['customfield_type'])){
-	    	$type = strtoupper($params['customfield_type']);
-	    }
 
-	    $meta_query['orderby_clause'] = array(
+      // If not set, defaults to 'CHAR' (as per WP docs).
+	  $type = 'CHAR';
+	  if( isset($params['customfield_type']) ) {
+	    $type = strtoupper($params['customfield_type']);
+	  }
+
+	  $meta_query['orderby_clause'] = array(
         'key' => $params['customfield_orderby'],
         'compare' => 'EXISTS',
         'type' => $type,

--- a/include/lcp-meta-query.php
+++ b/include/lcp-meta-query.php
@@ -84,17 +84,14 @@ trait LcpMetaQuery {
   private function check_customfield_orderby($params, &$meta_query) {
     if ( $params['customfield_orderby'] ) {
 
-      // If not set, defaults to 'CHAR' (as per WP docs).
-	  $type = 'CHAR';
-	  if( isset($params['customfield_type']) ) {
-	    $type = strtoupper($params['customfield_type']);
-	  }
-
 	  $meta_query['orderby_clause'] = array(
         'key' => $params['customfield_orderby'],
         'compare' => 'EXISTS',
-        'type' => $type,
       );
+
+      if( !empty($params['customfield_type']) ) {
+        $meta_query['orderby_clause']['type'] = strtoupper($params['customfield_type']);
+      }
     }
   }
 

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -108,7 +108,7 @@ class ListCategoryPosts{
         'customfield_display_name_glue' => ' : ',
         'customfield_display_separately' => 'no',
         'customfield_orderby' => '',
-        'customfield_type' => '',
+        'customfield_orderby_type' => '',
         'customfield_tag' => '',
         'customfield_class' => '',
         'customfield_compare' => '',

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -108,6 +108,7 @@ class ListCategoryPosts{
         'customfield_display_name_glue' => ' : ',
         'customfield_display_separately' => 'no',
         'customfield_orderby' =>'',
+        'customfield_type' => '',
         'customfield_tag' => '',
         'customfield_class' => '',
         'customfield_compare' => '',

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -107,7 +107,7 @@ class ListCategoryPosts{
         'customfield_display_name' =>'',
         'customfield_display_name_glue' => ' : ',
         'customfield_display_separately' => 'no',
-        'customfield_orderby' =>'',
+        'customfield_orderby' => '',
         'customfield_type' => '',
         'customfield_tag' => '',
         'customfield_class' => '',


### PR DESCRIPTION
- customfield_orderby - You can order the posts by a custom field. For example: [catlist numberposts=-1 customfield_orderby=Mood order=desc] will list all the posts with a "Mood" custom field. This parameter can be used toghether with customfield_name and customfield_value, you can use those parameters to select posts and then customfield_orderby to sort by this or another custom field. For other than alphabetical sorting, you can use customfield_type parameter (NUMERIC, BINARY, CHAR, DATE, DATETIME, DECIMAL, SIGNED, TIME, UNSIGNED). Remember the default order is descending, more on order: