### PR TITLE
Customize LCP query behavior

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -43,7 +43,7 @@ class CatList{
    * Determine the categories of posts and execute the WP_query
    */
   public function get_posts() {
-    $this->set_lcp_parameters();
+     return $this->set_lcp_parameters();
   }
 
   /**
@@ -88,11 +88,21 @@ class CatList{
     // http://core.trac.wordpress.org/browser/tags/3.7.1/src/wp-includes/post.php#L1686
     $args['posts_per_page'] = $args['numberposts'];
 
-    query_posts($args);
-    global $wp_query;
-    $this->posts_count = $wp_query->found_posts;
+    if ('no' === $this->params['main_query']) {
+      // Use a standard Loop with WP_Query.
+      $lcp_query = new WP_Query($args);
+    } else {
+      // Run as a main query.
+      query_posts($args);
+      global $wp_query;
+      $lcp_query = $wp_query;
+    }
+    $this->posts_count = $lcp_query->found_posts;
+
     remove_all_filters('posts_orderby');
     remove_filter('posts_where', array(LcpParameters::get_instance(), 'starting_with'));
+
+    return $lcp_query;
   }
 
   /* Should I return posts or show that the tag/category or whatever

--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -14,6 +14,7 @@ class CatListDisplayer {
   private $templater;
   private $params = array();
   private $lcp_output;
+  private $lcp_query;
 
   public function __construct($atts) {
     $this->params = $atts;
@@ -25,11 +26,18 @@ class CatListDisplayer {
   }
 
   public function display(){
-    $this->catlist->save_wp_query();
-    $this->catlist->get_posts();
-    $this->create_output();
-    $this->catlist->restore_wp_query();
-    wp_reset_query();
+    if ('no' === $this->params['main_query']) {
+      $this->lcp_query = $this->catlist->get_posts();
+      $this->create_output();
+      wp_reset_postdata();
+    } else {
+      $this->catlist->save_wp_query();
+      $this->lcp_query = $this->catlist->get_posts();
+      $this->create_output();
+      $this->catlist->restore_wp_query();
+      wp_reset_query();
+    }
+
     return $this->lcp_output;
   }
 

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -149,7 +149,8 @@ class ListCategoryPosts{
         'before_day' => '',
         'tags_as_class' => 'no',
         'pagination_bookmarks' => '',
-        'ol_offset' => ''
+        'ol_offset' => '',
+        'main_query' => '',
       );
     }
     return self::$default_params;

--- a/templates/default.php
+++ b/templates/default.php
@@ -59,10 +59,13 @@ $lcp_display_output .= $this->open_outer_tag('ul', 'lcp_catlist');
  * you'll see get_excerpt, get_thumbnail, etc.  You can now pass an
  * html tag as a parameter. This tag will sorround the info you want
  * to display. You can also assign a specific CSS class to each field.
+ *
+ * IMPORTANT: Prior to v0.85 lines 65-67 were different. Make sure your
+ * template is up to date.
 */
 global $post;
-while ( have_posts() ):
-  the_post();
+while ( $this->lcp_query->have_posts() ):
+  $this->lcp_query->the_post();
 
   // Check if protected post should be displayed
   if (!$this->check_show_protected($post)) continue;

--- a/tests/catlist/test-getPosts.php
+++ b/tests/catlist/test-getPosts.php
@@ -1,0 +1,25 @@
+<?php
+
+class Tests_CatList_GetPosts extends WP_UnitTestCase {
+
+  public function test_main_query_behavior_by_default() {
+    self::factory()->post->create_many(2);
+    $catlist = new CatList(ListCategoryPosts::default_params());
+    $query = $catlist->get_posts();
+
+    global $wp_query;
+    $this->assertSame($query, $wp_query);
+  }
+
+  public function test_secondary_query() {
+    self::factory()->post->create_many(2);
+    $catlist = new CatList(array_merge(
+      ListCategoryPosts::default_params(),
+      ['main_query' => 'no']
+    ));
+    $query = $catlist->get_posts();
+
+    global $wp_query;
+    $this->assertNotSame($query, $wp_query);
+  }
+}


### PR DESCRIPTION
Introduces `main_query=no` which makes the plugin create a standard secondary loop with WP_Query instead of using `query_posts()` which modifies the main query.

To be honest the plugin should use WP_Query be default and `query_posts()` should be an option but to keep things backward compatible, also with old templates, I came up with this implementation.

Fixes #445 