### PR TITLE
Add PHPUnit-Polyfills to CI setup

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,11 +12,10 @@ jobs:
       WP_TESTS_DIR: /tmp/wordpress-tests-lib
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4']
-        phpunit-versions: ['7.5.20']
+        php-versions: ['7.4', '8.0']
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
         ports:
@@ -30,24 +29,10 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         ini-values: post_max_size=256M, max_execution_time=180
-        coverage: xdebug        
-        tools: php-cs-fixer, phpunit:${{ matrix.phpunit-versions }}
+        coverage: xdebug
+        tools: phpunit-polyfills
         extensions: mysql
-    # - name: Shutdown Ubuntu MySQL (SUDO)
-    #   run: sudo service mysql stop
-    # - name: Install MySQL
-    #   uses: mirromutth/mysql-action@v1.1
-    #   with:
-    #     # host port: 3800
-    #     # container port: 3307 # Optional, default value is 3306. The port of container
-    #     character set server: 'utf8'
-    #     collation server: 'utf8_general_ci'
-    #     mysql version: '8.0'
-    #     mysql database: 'wordpress_test'
-    #     mysql root password: 'root'
-    #     mysql user: 'wordpressuser'
-    #     mysql password: 'wordpresspass'
     - name: Install WP Tests
-      run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:3306
+      run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:3306 trunk
     - name: Run tests
       run: phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ Desktop.ini
 ## Misc
 #################
 
+.phpunit.result.cache
+
 # Netbeans project meta data
 nbproject/
 
@@ -57,3 +59,8 @@ nbproject/
 vagrant
 wordpress/
 ubuntu*
+
+# Composer
+vendor/
+composer.json
+composer.lock

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.provision :shell, :path => "bin/bootstrap.sh"
   config.vm.network :forwarded_port, guest: 80, host: 8080
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="LCP CI tests">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,15 +6,29 @@
  */
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+
 if ( ! $_tests_dir ) {
-	$_tests_dir = '/var/www/wp-tests-lib';
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
-require_once $_tests_dir . '/includes/functions.php';
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+  echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+  exit( 1 );
+}
 
+// Give access to tests_add_filter() function.
+require_once "{$_tests_dir}/includes/functions.php";
+
+/**
+ * Manually load the plugin being tested.
+ */
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/list-category-posts.php';
 }
+
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-require $_tests_dir . '/includes/bootstrap.php';
+require_once trim(shell_exec('composer global config home')) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+
+// Start up the WP testing environment.
+require "{$_tests_dir}/includes/bootstrap.php";


### PR DESCRIPTION
As of September 2021 WordPress 5.9 and above require
PHPUnit-Polyfills for WordPress PHP Test Suite to work.

https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/