### PR TITLE
Fix multiple CSS classes

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -544,7 +544,7 @@ class CatList{
       $props['start'] = $start;
     }
     //Give a class to wrapper tag
-    $props['class'] = $css_class;
+    $props['class'] = LcpUtils::sanitize_html_classes($css_class);
 
     //Give id to wrapper tag
     $props['id'] = 'lcp_instance_' . $this->instance;

--- a/include/lcp-utils.php
+++ b/include/lcp-utils.php
@@ -58,4 +58,15 @@ class LcpUtils{
       return $value;
     };
   }
+
+  // Adapted from a comment on https://developer.wordpress.org/reference/functions/sanitize_html_class/
+  public static function sanitize_html_classes($classes, $sep = " ") {
+    if(!is_array($classes)) {
+      $classes = explode($sep, $classes);
+    }
+
+    $classes = array_map('sanitize_html_class', $classes);
+
+    return implode(' ', $classes);
+  }
 }

--- a/include/lcp-wrapper.php
+++ b/include/lcp-wrapper.php
@@ -4,6 +4,9 @@
  * defined by the user, both in shortcode parameters (e.g. comments_tag)
  * and in template method calls.
  */
+
+require_once 'lcp-utils.php';
+
 class LcpWrapper {
 
   // Singleton implementation
@@ -34,7 +37,7 @@ class LcpWrapper {
       elseif (!empty($tag) && empty($css_class)) :
         return $this->to_html($tag, [], $info);
       endif;
-      $css_class = sanitize_html_class($css_class);
+      $css_class = LcpUtils::sanitize_html_classes($css_class);
       return $this->to_html($tag, ['class' => $css_class], $info);
     endif;
   }

--- a/tests/lcpwrapper/test-wrap.php
+++ b/tests/lcpwrapper/test-wrap.php
@@ -39,4 +39,11 @@ class Tests_LcpWrapper_Wrap extends WP_UnitTestCase {
                       '<p class="test">an</p><p class="test">array</p>',
                       $wrapper->wrap($test_array, 'p', 'test'));
   }
+
+  public function test_multiple_classes() {
+    $wrapper = LcpWrapper::get_instance();
+    $this->assertSame(
+      '<span class="test1 test2 test3">test string</span>',
+      $wrapper->wrap($this->test_string, null, 'test1 test2 test3'));
+  }
 }


### PR DESCRIPTION
https://wordpress.org/support/topic/target-multiple-css-elements/#post-15307010

When trying to apply more than one class, the classes where glued together without a separator.