### PR TITLE
Allow customisation of sticky posts for categories

### DIFF
--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -38,6 +38,9 @@ class CatListDisplayer {
       wp_reset_query();
     }
 
+    // This filter needs to be removed after template code has executed, not before.
+    remove_filter( 'the_posts', [ LcpParameters::get_instance(), 'move_sticky_to_top' ] );
+
     return $this->lcp_output;
   }
 

--- a/include/lcp-parameters.php
+++ b/include/lcp-parameters.php
@@ -152,7 +152,26 @@ class LcpParameters{
       $args['ignore_sticky_posts'] = true;
     }
 
+    if ( $params[ 'cat_sticky_posts' ] === 'yes' ) {
+      add_filter( 'the_posts', [$this, 'move_sticky_to_top']);
+    }
+
     return $args;
+  }
+
+  public function move_sticky_to_top( $posts ) {
+    $sticky_ids = get_option( 'sticky_posts' );
+    $newposts = [];
+
+    foreach ( $posts as $post ) {
+      if ( in_array( $post->ID, $sticky_ids ) ) {
+        array_unshift( $newposts, $post );
+      } else {
+        $newposts[] = $post;
+      }
+    }
+
+    return $newposts;
   }
 
     private function lcp_check_basic_params($args){

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -168,6 +168,7 @@ class ListCategoryPosts{
         'main_query' => '',
         'keep_orderby_filters' => '',
         'ignore_sticky_posts' => '',
+        'cat_sticky_posts' => '',
       );
     }
     return self::$default_params;


### PR DESCRIPTION
By default when using `name` or `cat` WP_Query will get
all posts matching given categories but order them normally,
including sticky posts. This change allows users to put sticky
posts at the top in this kind of queries.

Fixes #423