### PR TITLE
Add filtering by main category only

### DIFF
--- a/include/lcp-catlist.php
+++ b/include/lcp-catlist.php
@@ -79,6 +79,7 @@ class CatList{
       'name'             => $this->params['name'],
       'categorypage'     => $this->params['categorypage'],
       'child_categories' => $this->params['child_categories'],
+      'main_cat_only'    => $this->params['main_cat_only'],
     ], $this->lcp_category_id);
     $processed_params = LcpParameters::get_instance()->get_query_params($this->params);
     $args = array_merge($args, $processed_params);
@@ -105,6 +106,7 @@ class CatList{
       remove_all_filters('posts_orderby');
     }
     remove_filter('posts_where', array(LcpParameters::get_instance(), 'starting_with'));
+    remove_filter('posts_results', [ LcpCategory::get_instance(), 'filter_by_main_category' ]);
 
     return $lcp_query;
   }

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -170,6 +170,7 @@ class ListCategoryPosts{
         'keep_orderby_filters' => '',
         'ignore_sticky_posts' => '',
         'cat_sticky_posts' => '',
+        'main_cat_only' => '',
       );
     }
     return self::$default_params;

--- a/tests/lcpcategory/test-getLcpCategory.php
+++ b/tests/lcpcategory/test-getLcpCategory.php
@@ -31,6 +31,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => '',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -43,6 +44,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => 'Dogs',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -59,6 +61,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => '',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -71,6 +74,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => '',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -84,6 +88,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => 'Dogs,Cats',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -100,6 +105,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => '',
           'categorypage'     => '',
           'child_categories' => 'no',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -113,6 +119,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => 'Dogs,Cats',
           'categorypage'     => '',
           'child_categories' => 'no',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -129,6 +136,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => '',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -142,6 +150,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => 'Dogs+Cats',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -157,6 +166,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
           'name'             => '',
           'categorypage'     => '',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -172,6 +182,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
         [
           'categorypage'     => 'yes',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -181,6 +192,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
         [
           'categorypage'     => 'other',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );
@@ -190,6 +202,7 @@ class Tests_LcpCategory_GetLcpCategory extends WP_UnitTestCase {
         [
           'categorypage'     => 'all',
           'child_categories' => 'yes',
+          'main_cat_only'    => '',
         ]
       )
     );


### PR DESCRIPTION
Allow filtering by posts' main/primary category only. Supports Yoast's "primary category" feature; falls back to first assigned category.

Usage `[catlist name="Foo" main_cat_only=yes]`

Resolves #449 