### PR TITLE
Updates fix for stored cross-site scripting from 0.90.0, now applied to all tags.

### DIFF
--- a/include/lcp-catlistdisplayer.php
+++ b/include/lcp-catlistdisplayer.php
@@ -178,13 +178,6 @@ class CatListDisplayer {
       $info = $this->catlist->get_content($post);
       break;
     case 'excerpt':
-      # Security vulnerability fix for Stored Cross-Site Scripting
-      # If a post has this excerpt: alert(/XSS/)
-      # Another post could use  [catlist excerpt_tag='script' excerpt=yes]
-      # and the XSS would be triggered.
-      if ( $tag == 'script' ) {
-        $tag = null;
-      }
       $info = $this->catlist->get_excerpt($post);
       if ( ! empty( $info ) ) {
         $info = preg_replace('/\[.*\]/', '', $info);

--- a/include/lcp-wrapper.php
+++ b/include/lcp-wrapper.php
@@ -29,6 +29,15 @@ class LcpWrapper {
    * @return string
    */
   private function assign_style($info, $tag = null, $css_class = null){
+    # Security vulnerability fix for Stored Cross-Site Scripting
+    # If a field stores some malicious JavaScript, it could be displayed with the 'script' tag, so
+    # that tag needs to be excluded.
+    # e.g. If a post has this excerpt: alert(/XSS/) another post could use:
+    # [catlist excerpt_tag='script' excerpt=yes]
+    # and the XSS would be triggered.
+    if ( $tag == 'script' ) {
+      $tag = null;
+    }
     if (!empty($info)):
       if (empty($tag) && !empty($css_class)):
         $tag = "span";
@@ -53,7 +62,6 @@ class LcpWrapper {
    * @return string
    */
   public function wrap($info, $tag=null, $css_class=null) {
-
     $wrapped = '';
 
     if (is_array($info)) {

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -3,7 +3,7 @@
   Plugin Name: List category posts
   Plugin URI: https://github.com/picandocodigo/List-Category-Posts
   Description: List Category Posts allows you to list posts by category in a post/page using the [catlist] shortcode. This shortcode accepts a category name or id, the order in which you want the posts to display, the number of posts to display and many more parameters. You can use [catlist] as many times as needed with different arguments. Usage: [catlist argument1=value1 argument2=value2].
-  Version: 0.90.1
+  Version: 0.90.2
   Author: Fernando Briano
   Author URI: http://fernandobriano.com
 

--- a/readme.txt
+++ b/readme.txt
@@ -237,6 +237,10 @@ Template system has changed. Custom templates should be stored in WordPress them
 
 == Changelog ==
 
+= 0.90.2 =
+
+* Updates fix for stored cross-site scripting from 0.90.0, now applied to all tags. From this version onwards, script is not available to use as a tag when setting an element's tag in the shortcode.
+
 = 0.90.1 =
 
 * Fix PHP 8.2 deprecation notices


### PR DESCRIPTION
Bumps version to 0.90.2

@klemens-st Another way to trigger an XSS with `script` was reported for different fields. As we've talked before, the vulnerabilites are present when WordPress has already been compromised, since the malintentioned user would need permision to publish content on the system to trigger them. But if it helps keeping a site safer, then why not... :shrug:

Ideally I think it's up to the users to use or not use `<script>` with the plugin, so eventually we *could* make this optional (warning the users they should really know what they're doing if they want to allow it).  But I think it's also ok not to support the `script` tag.

I think this is the best place in the code to remove support for `<script>` since it's the function `wrap` uses, and the times `to_html` is used in other places seems to be safe. Let me know what you think.