### PR TITLE
Harden xss security fix

### DIFF
--- a/include/lcp-wrapper.php
+++ b/include/lcp-wrapper.php
@@ -35,7 +35,7 @@ class LcpWrapper {
     # e.g. If a post has this excerpt: alert(/XSS/) another post could use:
     # [catlist excerpt_tag='script' excerpt=yes]
     # and the XSS would be triggered.
-    if ( !empty( $tag ) && tag_escape( $tag ) == 'script' ) {
+    if ( !empty( $tag ) && strtolower( tag_escape( $tag ) ) == 'script' ) {
       $tag = null;
     }
     if (!empty($info)):

--- a/include/lcp-wrapper.php
+++ b/include/lcp-wrapper.php
@@ -35,7 +35,7 @@ class LcpWrapper {
     # e.g. If a post has this excerpt: alert(/XSS/) another post could use:
     # [catlist excerpt_tag='script' excerpt=yes]
     # and the XSS would be triggered.
-    if ( $tag == 'script' ) {
+    if ( !empty( $tag ) && tag_escape( $tag ) == 'script' ) {
       $tag = null;
     }
     if (!empty($info)):

--- a/list-category-posts.php
+++ b/list-category-posts.php
@@ -3,7 +3,7 @@
   Plugin Name: List category posts
   Plugin URI: https://github.com/picandocodigo/List-Category-Posts
   Description: List Category Posts allows you to list posts by category in a post/page using the [catlist] shortcode. This shortcode accepts a category name or id, the order in which you want the posts to display, the number of posts to display and many more parameters. You can use [catlist] as many times as needed with different arguments. Usage: [catlist argument1=value1 argument2=value2].
-  Version: 0.90.2
+  Version: 0.90.3
   Author: Fernando Briano
   Author URI: http://fernandobriano.com
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: list, categories, posts, cms
 Requires at least: 3.3
 Tested up to: 6.7.1
 Requires PHP: 5.6
-Stable tag: 0.90.2
+Stable tag: 0.90.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -236,6 +236,10 @@ Widget built for WordPress 2.8's Widget API, so you need at least WP 2.8 to use 
 Template system has changed. Custom templates should be stored in WordPress theme folder.
 
 == Changelog ==
+
+= 0.90.3 =
+
+* Hardens xss fix for script tag by checking case insensitive and using tag_escape.
 
 = 0.90.2 =
 

--- a/tests/lcpwrapper/test-wrap.php
+++ b/tests/lcpwrapper/test-wrap.php
@@ -46,4 +46,28 @@ class Tests_LcpWrapper_Wrap extends WP_UnitTestCase {
       '<span class="test1 test2 test3">test string</span>',
       $wrapper->wrap($this->test_string, null, 'test1 test2 test3'));
   }
+
+  public function test_script_tag() {
+    $wrapper = LcpWrapper::get_instance();
+    $this->assertSame(
+      '<span class="test">test string</span>',
+      $wrapper->wrap($this->test_string, 'script', 'test')
+    );
+    $this->assertSame(
+      'test string',
+      $wrapper->wrap($this->test_string, 'script', null)
+    );
+    $this->assertSame(
+      'test string',
+      $wrapper->wrap($this->test_string, 'SCRIPT', null)
+    );
+    $this->assertSame(
+      'test string',
+      $wrapper->wrap($this->test_string, 'sCrIpt', null)
+    );
+    $this->assertSame(
+      'test string',
+      $wrapper->wrap($this->test_string, 's(cript', null)
+    );
+  }
 }


### PR DESCRIPTION
@picandocodigo I realised the fix from #526 works well when someone uses `excerpt_tag=script` but if someone tries `excerpt_tag="s(cript"` the fix is ineffective, because `to_html` receives this value, escapes it with `tag_escape` so in the end it becomes `script`.

This small change prevents that.