### PR TITLE
Add Subversion instllation step to CI workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,8 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
+    - name: Setup Subversion
+      run: sudo apt install subversion
     - name: Checkout
       uses: actions/checkout@v2
     - name: Setup PHP


### PR DESCRIPTION
Since Ubuntu 24.04 Github worker svn is no longer included and needs to be setup manually.