### PR TITLE
CVE-2025-47636

### DIFF
--- a/include/lcp-templater.php
+++ b/include/lcp-templater.php
@@ -131,6 +131,7 @@ class LcpTemplater {
    * @return bool         Is the template a proper php file.
    */
   private static function validate_template($path, $file) {
+    $file = str_replace('../', '', $file);
     return (substr($file, -4) == '.php' ) && is_file($path . $file) &&
       is_readable($path . $file);
   }

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: fernandobt, zymeth25
 Donate Link: http://picandocodigo.net/programacion/wordpress/list-category-posts-wordpress-plugin-english/#support
 Tags: list, categories, posts, cms
 Requires at least: 3.3
-Tested up to: 6.7.1
+Tested up to: 6.8.1
 Requires PHP: 5.6
-Stable tag: 0.90.3
+Stable tag: 0.91.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -236,6 +236,11 @@ Widget built for WordPress 2.8's Widget API, so you need at least WP 2.8 to use 
 Template system has changed. Custom templates should be stored in WordPress theme folder.
 
 == Changelog ==
+
+= 0.91.0 =
+
+* Addresses CVE-2025-47636, avoids Local File Inclusion for template system. The code will remove any occurrences of the string  '../' in the template parameter. Templates files must be php files located in a directory named `list-category-posts` under `wp-content/themes/your-theme-folder`.
+https://www.cve.org/CVERecord?id=CVE-2025-47636
 
 = 0.90.3 =
 


### PR DESCRIPTION
This should remove the possibilty of local file inclussion by not allowing `../` in the template parameter. 

However, the plugin still allows including php files from the theme's directory. If an attacker had access to the server's file system, they could upload or create an exploit in the current theme directory. If they also have access to the dashboard and permissions to write/edit posts and use the plugin, they could still include a bad file by using the template parameter.

Like previously reported vulnerabilities, **to take advantage of this vulnerability, the whole system needs to have already been compromised**.

We can still make the plugin more secure, but I'm not sure if this fix would be enough to consider this vulnerability fixed. The alternative would be to completely remove the template system which I think is a core functionality and probably lots of users are taking advantage of.

Closes #533